### PR TITLE
Security fix + mcp unit tests + maintenance timer

### DIFF
--- a/cmd/anchored/main.go
+++ b/cmd/anchored/main.go
@@ -73,6 +73,8 @@ func main() {
 		runEval(os.Args[2:])
 	case "backfill":
 		runBackfillEmbeddings(os.Args[2:])
+	case "maintenance":
+		runMaintenance(os.Args[2:])
 	case "--version", "-v":
 		fmt.Printf("anchored %s\n", Version)
 	case "--help", "-h":
@@ -117,6 +119,8 @@ func printUsage() {
 	fmt.Fprintf(os.Stderr, "  anchored artifact prune     Remove expired artifacts\n")
 	fmt.Fprintf(os.Stderr, "  anchored remote status      Show remote sync config status\n")
 	fmt.Fprintf(os.Stderr, "  anchored remote preview     Preview which memories would sync (offline)\n")
+	fmt.Fprintf(os.Stderr, "  anchored maintenance run    Periodic upkeep: import + dream + curation reconcile\n")
+	fmt.Fprintf(os.Stderr, "  anchored maintenance install  Install upkeep as a systemd --user daily timer\n")
 	fmt.Fprintf(os.Stderr, "  anchored --version          Print version\n")
 	fmt.Fprintf(os.Stderr, "\nImport sources: claude-code devclaw opencode cursor all\n")
 	fmt.Fprintf(os.Stderr, "\nFlags:\n")

--- a/cmd/anchored/maintenance.go
+++ b/cmd/anchored/maintenance.go
@@ -1,0 +1,307 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+// anchored maintenance automates the periodic upkeep that otherwise only runs
+// on demand or while an agent is connected to `anchored serve`:
+//
+//   - import   — pull fresh memories from Claude Code / OpenCode / Cursor
+//   - dream    — consolidate (dedup, merge, flag contradictions)
+//   - curation — reconcile quality/importance scores
+//
+// `anchored maintenance run` executes the three steps as isolated subprocesses
+// (a failure in one step is logged but does not abort the others). `install`
+// wires that command into a systemd --user timer so it runs every day without
+// any agent connected — the same pattern as `anchored dashboard install`.
+
+func runMaintenance(args []string) {
+	if len(args) == 0 {
+		printMaintenanceUsage()
+		return
+	}
+	switch args[0] {
+	case "run":
+		runMaintenanceRun(args[1:])
+	case "install":
+		installMaintenanceService()
+	case "uninstall":
+		uninstallMaintenanceService()
+	case "status":
+		statusMaintenanceService()
+	default:
+		printMaintenanceUsage()
+		os.Exit(2)
+	}
+}
+
+func printMaintenanceUsage() {
+	fmt.Fprintln(os.Stderr, "Usage: anchored maintenance <run|install|uninstall|status>")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Periodic upkeep: import fresh memories, dream (consolidate),")
+	fmt.Fprintln(os.Stderr, "and reconcile curation scores — either once or on a timer.")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Commands:")
+	fmt.Fprintln(os.Stderr, "  anchored maintenance run         run import + dream + curation now")
+	fmt.Fprintln(os.Stderr, "  anchored maintenance install     install a systemd --user daily timer")
+	fmt.Fprintln(os.Stderr, "  anchored maintenance uninstall   remove the timer")
+	fmt.Fprintln(os.Stderr, "  anchored maintenance status      show timer status")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Flags for `run`:")
+	fmt.Fprintln(os.Stderr, "  --config PATH            config file path")
+	fmt.Fprintln(os.Stderr, "  --aggressiveness LEVEL   dream level: conservative|moderate|aggressive (default moderate)")
+	fmt.Fprintln(os.Stderr, "  --max-deletions N        max soft-deletions per dream run (default 50)")
+	fmt.Fprintln(os.Stderr, "  --skip-import            skip the import step")
+	fmt.Fprintln(os.Stderr, "  --skip-dream             skip the dream step")
+	fmt.Fprintln(os.Stderr, "  --skip-curation          skip the curation reconcile step")
+}
+
+// runMaintenanceRun executes the upkeep steps as isolated subprocesses.
+// Subprocess isolation (rather than calling runImport/runDream directly) keeps
+// a crash or os.Exit in one step from aborting the others, and mirrors what the
+// systemd unit will do in production.
+func runMaintenanceRun(args []string) {
+	fs := newFlagSet("maintenance run")
+	configPath := fs.String("config", "", "path to config file")
+	aggressiveness := fs.String("aggressiveness", "moderate", "dream aggressiveness: conservative, moderate, aggressive")
+	maxDeletions := fs.Int("max-deletions", 50, "maximum soft-deletions per dream run")
+	skipImport := fs.Bool("skip-import", false, "skip the import step")
+	skipDream := fs.Bool("skip-dream", false, "skip the dream step")
+	skipCuration := fs.Bool("skip-curation", false, "skip the curation reconcile step")
+	fs.Parse(args)
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	exe, err := maintenanceExe()
+	if err != nil {
+		slog.Error("locate executable", "error", err)
+		os.Exit(1)
+	}
+
+	start := time.Now()
+	results := []struct {
+		step string
+		ok   bool
+	}{}
+
+	runStep := func(step string, skip bool, build func() *exec.Cmd) {
+		if skip {
+			logger.Info("maintenance: step skipped", "step", step)
+			return
+		}
+		logger.Info("maintenance: step start", "step", step)
+		t0 := time.Now()
+		cmd := build()
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		err := cmd.Run()
+		dur := time.Since(t0).Round(time.Millisecond)
+		if err != nil {
+			logger.Error("maintenance: step failed", "step", step, "duration", dur, "error", err)
+			results = append(results, struct {
+				step string
+				ok   bool
+			}{step, false})
+			return
+		}
+		logger.Info("maintenance: step done", "step", step, "duration", dur)
+		results = append(results, struct {
+			step string
+			ok   bool
+		}{step, true})
+	}
+
+	// 1. Import — pulls fresh memories from connected tools. Embeddings are
+	// generated inline by the importer.
+	runStep("import", *skipImport, func() *exec.Cmd {
+		return maintenanceCmd(exe, *configPath, "import", "all")
+	})
+
+	// 2. Dream — analyze + apply consolidation. --dry-run=false forces apply
+	// (the flag defaults to dry-run=true for interactive safety).
+	runStep("dream", *skipDream, func() *exec.Cmd {
+		cmd := maintenanceCmd(exe, *configPath, "dream",
+			"--dry-run=false",
+			"--aggressiveness", *aggressiveness,
+			fmt.Sprintf("--max-deletions=%d", *maxDeletions),
+		)
+		return cmd
+	})
+
+	// 3. Curation — reconcile quality/importance metadata. --yes skips the
+	// interactive confirmation prompt (unsupervised timer context).
+	runStep("curation", *skipCuration, func() *exec.Cmd {
+		return maintenanceCmd(exe, *configPath, "curation", "reconcile", "--yes")
+	})
+
+	failed := 0
+	for _, r := range results {
+		if !r.ok {
+			failed++
+		}
+	}
+	logger.Info("maintenance: run complete",
+		"steps", len(results), "failed", failed, "duration", time.Since(start).Round(time.Millisecond))
+	if failed > 0 {
+		os.Exit(1)
+	}
+}
+
+// maintenanceCmd builds a subprocess for one upkeep step, threading --config
+// through only when set so the default config discovery still applies.
+func maintenanceCmd(exe, configPath, sub string, extra ...string) *exec.Cmd {
+	args := []string{sub}
+	args = append(args, extra...)
+	if configPath != "" {
+		args = append(args, "--config", configPath)
+	}
+	return exec.Command(exe, args...)
+}
+
+// maintenanceExe resolves the anchored binary to invoke for sub-steps. Prefers
+// the running executable (so the timer uses the exact version that installed
+// it), falling back to PATH lookup.
+func maintenanceExe() (string, error) {
+	if exe, err := os.Executable(); err == nil {
+		if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+			return resolved, nil
+		}
+		return exe, nil
+	}
+	return exec.LookPath("anchored")
+}
+
+// --- systemd --user timer management (Linux only; best-effort) ---
+
+const maintenanceUnitName = "anchored-maintenance"
+
+// runCmd runs a command streaming output to stderr. Failure is non-fatal —
+// service management must degrade gracefully across distros/environments.
+func runCmd(name string, args ...string) bool {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "  (warning) %s: %v\n", name, err)
+		return false
+	}
+	return true
+}
+
+func maintenanceUnitDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "systemd", "user"), nil
+}
+
+// maintenanceUnit is the oneshot service the timer fires. It calls
+// `anchored maintenance run`, which chains import + dream + curation.
+func maintenanceUnit(exe string) string {
+	return fmt.Sprintf(`[Unit]
+Description=anchored periodic upkeep (import + dream + curation)
+
+[Service]
+Type=oneshot
+ExecStart=%s maintenance run
+`, exe)
+}
+
+// maintenanceTimer schedules the oneshot daily, with a small randomized delay
+// so a fleet of machines doesn't stampede at exactly 04:00. Persistent=true
+// catches up a missed run after suspend/shutdown.
+func maintenanceTimer() string {
+	return `# Persistent: run a missed activation after suspend/boot.
+# RandomizedDelaySec spreads load if multiple hosts run this.
+[Unit]
+Description=anchored maintenance daily timer
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+RandomizedDelaySec=15min
+
+[Install]
+WantedBy=timers.target
+`
+}
+
+func installMaintenanceService() {
+	if runtime.GOOS != "linux" {
+		fmt.Fprintln(os.Stderr, "maintenance timer install is Linux-only (systemd --user).")
+		fmt.Fprintln(os.Stderr, "Use cron to schedule `anchored maintenance run` on other platforms.")
+		os.Exit(1)
+	}
+	exe, err := maintenanceExe()
+	if err != nil {
+		slog.Error("locate executable", "error", err)
+		os.Exit(1)
+	}
+
+	dir, err := maintenanceUnitDir()
+	if err != nil {
+		slog.Error("resolve unit dir", "error", err)
+		os.Exit(1)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		slog.Error("create unit dir", "error", err)
+		os.Exit(1)
+	}
+
+	unitPath := filepath.Join(dir, maintenanceUnitName+".service")
+	if err := os.WriteFile(unitPath, []byte(maintenanceUnit(exe)), 0o644); err != nil {
+		slog.Error("write service unit", "error", err)
+		os.Exit(1)
+	}
+	timerPath := filepath.Join(dir, maintenanceUnitName+".timer")
+	if err := os.WriteFile(timerPath, []byte(maintenanceTimer()), 0o644); err != nil {
+		slog.Error("write timer unit", "error", err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stderr, "units written:\n  %s\n  %s\n", unitPath, timerPath)
+
+	// Lingering lets the user service run after logout and start at boot;
+	// harmless if already enabled or if loginctl is missing.
+	if user := os.Getenv("USER"); user != "" {
+		runCmd("loginctl", "enable-linger", user)
+	}
+	runCmd("systemctl", "--user", "daemon-reload")
+	runCmd("systemctl", "--user", "enable", "--now", maintenanceUnitName+".timer")
+
+	fmt.Fprintf(os.Stderr, "\nanchored maintenance timer enabled (runs daily).\n")
+	fmt.Fprintf(os.Stderr, "  next run: systemctl --user list-timers %s.timer\n", maintenanceUnitName)
+	fmt.Fprintf(os.Stderr, "  run now:  anchored maintenance run\n")
+	fmt.Fprintf(os.Stderr, "  logs:     journalctl --user -u %s -f\n", maintenanceUnitName)
+	fmt.Fprintf(os.Stderr, "  remove:   anchored maintenance uninstall\n")
+}
+
+func uninstallMaintenanceService() {
+	runCmd("systemctl", "--user", "disable", "--now", maintenanceUnitName+".timer")
+	if dir, err := maintenanceUnitDir(); err == nil {
+		_ = os.Remove(filepath.Join(dir, maintenanceUnitName+".timer"))
+		_ = os.Remove(filepath.Join(dir, maintenanceUnitName+".service"))
+	}
+	runCmd("systemctl", "--user", "daemon-reload")
+	fmt.Fprintf(os.Stderr, "anchored maintenance timer removed.\n")
+}
+
+func statusMaintenanceService() {
+	cmd := exec.Command("systemctl", "--user", "list-timers", maintenanceUnitName+".timer")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		// Fall back to the service status if the timer isn't installed.
+		cmd2 := exec.Command("systemctl", "--user", "status", maintenanceUnitName+".service")
+		cmd2.Stdout = os.Stdout
+		cmd2.Stderr = os.Stderr
+		_ = cmd2.Run()
+	}
+}

--- a/cmd/anchored/maintenance_test.go
+++ b/cmd/anchored/maintenance_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMaintenanceUnit_ContainsExecStart(t *testing.T) {
+	got := maintenanceUnit("/usr/local/bin/anchored")
+	if !strings.Contains(got, "Type=oneshot") {
+		t.Errorf("unit must be oneshot, got:\n%s", got)
+	}
+	if !strings.Contains(got, "ExecStart=/usr/local/bin/anchored maintenance run") {
+		t.Errorf("ExecStart must run `maintenance run`, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Description=anchored periodic upkeep") {
+		t.Errorf("missing description, got:\n%s", got)
+	}
+}
+
+func TestMaintenanceTimer_DailyPersistentJittered(t *testing.T) {
+	got := maintenanceTimer()
+	for _, want := range []string{"OnCalendar=daily", "Persistent=true", "RandomizedDelaySec=15min", "WantedBy=timers.target"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("timer missing %q, got:\n%s", want, got)
+		}
+	}
+}
+
+func TestMaintenanceCmd_ThreadsConfig(t *testing.T) {
+	// With configPath set, --config is appended after the step's own flags.
+	cmd := maintenanceCmd("/x/anchored", "/etc/anchored.yaml", "dream", "--dry-run=false")
+	got := strings.Join(cmd.Args, " ")
+	want := "/x/anchored dream --dry-run=false --config /etc/anchored.yaml"
+	if got != want {
+		t.Errorf("cmd with config: got %q, want %q", got, want)
+	}
+
+	// Without configPath, no --config flag is added (default discovery applies).
+	cmd2 := maintenanceCmd("/x/anchored", "", "import", "all")
+	got2 := strings.Join(cmd2.Args, " ")
+	want2 := "/x/anchored import all"
+	if got2 != want2 {
+		t.Errorf("cmd without config: got %q, want %q", got2, want2)
+	}
+}
+
+// TestRunMaintenanceRun_AllSkipped exercises the orchestration loop without
+// touching the DB or ONNX: every step is skipped, so no subprocess is spawned
+// and the run completes with zero steps. Validates that the dispatcher, flag
+// parsing, and completion logging hold together end-to-end. The success path
+// does not call os.Exit, so this is safe to invoke directly.
+func TestRunMaintenanceRun_AllSkipped(t *testing.T) {
+	// Discard the structured logs so the test output stays clean.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("runMaintenanceRun panicked: %v", r)
+		}
+	}()
+	runMaintenanceRun([]string{
+		"--skip-import", "--skip-dream", "--skip-curation",
+	})
+}

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -1,0 +1,121 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSetDebugLogger(t *testing.T) {
+	s := NewServer(nil, nil, nil, nil, nil, "", nil)
+	
+	// Test with nil logger (should not panic)
+	s.SetDebugLogger(nil)
+	if s.dlog != nil {
+		t.Error("expected dlog to be nil after SetDebugLogger(nil)")
+	}
+}
+
+func TestHeadTail(t *testing.T) {
+	tests := []struct {
+		name     string
+		s        string
+		head     int
+		tail     int
+		expected string
+	}{
+		{
+			name:     "short string passes through",
+			s:        "hello",
+			head:     10,
+			tail:     10,
+			expected: "hello",
+		},
+		{
+			name:     "truncates with head and tail",
+			s:        "abcdefghijklmnopqrstuvwxyz",
+			head:     5,
+			tail:     5,
+			expected: "abcde\n[... 16 bytes omitted ...]\nvwxyz",
+		},
+		{
+			name:     "empty string",
+			s:        "",
+			head:     5,
+			tail:     5,
+			expected: "",
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := headTail(tt.s, tt.head, tt.tail)
+			if result != tt.expected {
+				t.Errorf("headTail(%q, %d, %d) = %q; want %q", tt.s, tt.head, tt.tail, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMarshalResponse_ErrorPath(t *testing.T) {
+	// Force json.Marshal to fail by putting a non-marshalable value (channel) in Result.
+	// JSONRPCResponse.Result is `any`, so a chan triggers a marshal error, exercising the
+	// error branch that wraps the failure into an InternalError response.
+	resp := JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage("1"),
+		Result:  make(chan int), // channels cannot be JSON-marshaled
+	}
+	out := MarshalResponse(resp)
+	if len(out) == 0 {
+		t.Fatal("expected non-empty fallback response")
+	}
+	if !strings.Contains(string(out), "error") {
+		t.Errorf("expected error payload in fallback, got: %s", out)
+	}
+}
+
+func TestSearchHitWriter_HitAndOmit(t *testing.T) {
+	w := newSearchHitWriter(false)
+	w.open("<anchored_search query=\"%s\">", "test")
+
+	// Normal hit: within budget.
+	w.hit([]string{`id="1"`}, "first line\nsecond line")
+	out := w.sb.String()
+	if !strings.Contains(out, "<hit") || !strings.Contains(out, "first line second line") {
+		t.Errorf("expected flattened hit content, got: %s", out)
+	}
+
+	// Force the omitted path: fill the buffer near the 8KB budget with large hits,
+	// then add one more that cannot fit. Content is capped to searchHitRunes (700)
+	// per hit, so we need several to exhaust the budget.
+	big := strings.Repeat("y", searchHitRunes)
+	for i := 0; i < 12; i++ {
+		w.hit([]string{`id="fill"`}, big)
+	}
+	w.hit([]string{`id="overflow"`}, big)
+	if w.omitted == 0 {
+		t.Error("expected omitted counter to increment when hit exceeds budget")
+	}
+
+	// close() must emit the <omitted> note (omitted > 0) and the closing tag.
+	closed := w.close()
+	if !strings.Contains(closed, "<omitted") {
+		t.Errorf("expected <omitted> note in output, got: %s", closed)
+	}
+	if !strings.Contains(closed, "</anchored_search>") {
+		t.Error("expected closing tag in output")
+	}
+}
+
+func TestSearchHitWriter_CloseWithoutOmit(t *testing.T) {
+	w := newSearchHitWriter(true) // full=true branch
+	w.open("<anchored_search>")
+	closed := w.close()
+	if strings.Contains(closed, "<omitted") {
+		t.Errorf("did not expect <omitted> note when nothing was omitted, got: %s", closed)
+	}
+	if !strings.HasSuffix(strings.TrimSpace(closed), "</anchored_search>") {
+		t.Errorf("expected output to end with closing tag, got: %s", closed)
+	}
+}

--- a/pkg/memory/sqlite_store.go
+++ b/pkg/memory/sqlite_store.go
@@ -67,7 +67,11 @@ func (s *SQLiteStore) VectorCache() *VectorCache { return s.cache }
 
 func newUUID() string {
 	b := make([]byte, 16)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		// crypto/rand should never fail on a healthy system, but ignoring the
+		// error would silently return an all-zero (non-unique) id.
+		panic(fmt.Sprintf("crypto/rand failed: %v", err))
+	}
 	return hex.EncodeToString(b)
 }
 

--- a/pkg/project/detector.go
+++ b/pkg/project/detector.go
@@ -102,7 +102,11 @@ func gitRoot(dir string) (string, error) {
 
 func newID() string {
 	b := make([]byte, 16)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		// crypto/rand should never fail on a healthy system, but ignoring the
+		// error would silently return an all-zero (non-unique) id.
+		panic(err)
+	}
 	return hex.EncodeToString(b)
 }
 


### PR DESCRIPTION
Three small, independent improvements bundled here. Each commit is self-contained.

## 1. Security: check crypto/rand errors in id generators

`newID` (pkg/project/detector.go) and `newUUID` (pkg/memory/sqlite_store.go) called `rand.Read` and discarded the error, so a PRNG failure would silently yield all-zero, non-unique ids. `pkg/context/store.go` already had the check; this brings the other two in line. Panics on failure — crypto/rand failing signals a seriously broken system.

## 2. mcp unit tests for uncovered helpers

Adds unit tests for previously-uncovered pure helpers:
- `SetDebugLogger` — nil-safe setter
- `headTail` — UTF-8-aware truncation with omission marker
- `MarshalResponse` — marshal-failure fallback to `InternalError`
- `searchHitWriter` — hit budget-omit path + `<omitted>` note emission

Integration coverage for tool handlers already exists (`newTestServer`/`callToolJSON` in `server_ctx_test.go`), so these only fill the pure-helper gaps.

## 3. `anchored maintenance` — periodic upkeep timer

`anchored serve` is STDIO on-demand: its background workers (curation, indexer) only run while an agent is connected, and `dream`/`import` have no background path at all. `anchored maintenance` adds a persistent upkeep loop independent of any MCP client connection.

- `maintenance run` — chains `import all` → `dream --apply` → `curation reconcile --yes` as isolated subprocesses (one step failing logs + continues)
- `maintenance install` — writes a systemd --user oneshot `.service` + daily `.timer` (`Persistent=true`, 15m jitter), enables lingering + the timer
- `maintenance uninstall` / `status`

Flags for `run`: `--config`, `--aggressiveness`, `--max-deletions`, `--skip-import`/`-dream`/`-curation`. Linux-only install; other platforms use cron.

## Validation

Built and tested against `main` (mattn/go-sqlite3, FTS5): all packages pass.