### PR TITLE
fix(memory): stop the re-embed loop that kept semantic search off, plus bulk forget

### DIFF
--- a/cmd/anchored/forget.go
+++ b/cmd/anchored/forget.go
@@ -5,18 +5,49 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jholhewres/anchored/pkg/memory"
 )
 
 func runForget(args []string) {
 	fs := newFlagSet("forget")
 	configPath := fs.String("config", "", "path to config file")
 	hard := fs.Bool("hard", false, "permanently delete (default: soft delete)")
+	category := fs.String("category", "", "bulk: restrict to a category")
+	source := fs.String("source", "", "bulk: restrict to a source")
+	project := fs.String("project", "", "bulk: restrict to a project id")
+	olderThan := fs.String("older-than", "", "bulk: only memories created before this age (e.g. 60d, 12h)")
+	limit := fs.Int("limit", 0, "bulk: cap how many memories one run removes (0 = no cap)")
+	yes := fs.Bool("yes", false, "bulk: actually delete (without it, bulk mode only reports the count)")
 	fs.Parse(args)
 
 	id := fs.Arg(0)
-	if id == "" {
-		fmt.Fprintln(os.Stderr, "Usage: anchored forget <id> [--hard]")
+	bulk := *category != "" || *source != "" || *project != "" || *olderThan != ""
+
+	if id == "" && !bulk {
+		fmt.Fprintln(os.Stderr, "Usage:")
+		fmt.Fprintln(os.Stderr, "  anchored forget <id> [--hard]")
+		fmt.Fprintln(os.Stderr, "  anchored forget --category C [--older-than 60d] [--source S] [--project P] [--limit N] [--hard] --yes")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Bulk mode reports the match count and deletes nothing until --yes is passed.")
 		os.Exit(1)
+	}
+	if id != "" && bulk {
+		fmt.Fprintln(os.Stderr, "forget error: pass either an id or bulk filters, not both")
+		os.Exit(1)
+	}
+
+	var cutoff time.Time
+	if *olderThan != "" {
+		age, err := parseAge(*olderThan)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "forget error: %v\n", err)
+			os.Exit(1)
+		}
+		cutoff = time.Now().UTC().Add(-age)
 	}
 
 	_, _, svc, err := initService(*configPath)
@@ -28,17 +59,62 @@ func runForget(args []string) {
 
 	ctx := context.Background()
 
+	if bulk {
+		opts := memory.DeleteScopeOptions{
+			ProjectID: *project,
+			Category:  *category,
+			Source:    *source,
+			Hard:      *hard,
+			OlderThan: cutoff,
+			Limit:     *limit,
+			DryRun:    !*yes,
+		}
+		n, err := svc.ForgetScope(ctx, opts)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "forget error: %v\n", err)
+			os.Exit(1)
+		}
+		mode := "soft-delete"
+		if *hard {
+			mode = "permanent delete"
+		}
+		if opts.DryRun {
+			fmt.Printf("%d memories match (%s). Nothing deleted — pass --yes to apply.\n", n, mode)
+			return
+		}
+		fmt.Printf("%d memories removed (%s).\n", n, mode)
+		return
+	}
+
 	if *hard {
 		if err := svc.Forget(ctx, id); err != nil {
 			fmt.Fprintf(os.Stderr, "forget error: %v\n", err)
 			os.Exit(1)
 		}
 		fmt.Printf("Permanently deleted memory %s\n", id)
-	} else {
-		if err := svc.SoftForget(ctx, id); err != nil {
-			fmt.Fprintf(os.Stderr, "forget error: %v\n", err)
-			os.Exit(1)
-		}
-		fmt.Printf("Soft-deleted memory %s\n", id)
+		return
 	}
+	if err := svc.SoftForget(ctx, id); err != nil {
+		fmt.Fprintf(os.Stderr, "forget error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Soft-deleted memory %s\n", id)
+}
+
+// parseAge accepts the durations a retention cut is actually expressed in.
+// time.ParseDuration tops out at hours, so days get their own suffix.
+func parseAge(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if raw, ok := strings.CutSuffix(s, "d"); ok {
+		days, err := strconv.Atoi(raw)
+		if err != nil || days < 0 {
+			return 0, fmt.Errorf("invalid age %q: want something like 60d", s)
+		}
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d < 0 {
+		return 0, fmt.Errorf("invalid age %q: want something like 60d or 12h", s)
+	}
+	return d, nil
 }

--- a/cmd/anchored/forget.go
+++ b/cmd/anchored/forget.go
@@ -69,18 +69,41 @@ func runForget(args []string) {
 			Limit:     *limit,
 			DryRun:    !*yes,
 		}
-		n, err := svc.ForgetScope(ctx, opts)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "forget error: %v\n", err)
-			os.Exit(1)
-		}
 		mode := "soft-delete"
 		if *hard {
 			mode = "permanent delete"
 		}
+
 		if opts.DryRun {
-			fmt.Printf("%d memories match (%s). Nothing deleted — pass --yes to apply.\n", n, mode)
+			// Report the true match count alongside the capped one. With --limit
+			// the capped number alone reads as "that is all there is", which is
+			// the opposite of what it means.
+			capped, err := svc.ForgetScope(ctx, opts)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "forget error: %v\n", err)
+				os.Exit(1)
+			}
+			uncapped := capped
+			if opts.Limit > 0 {
+				noLimit := opts
+				noLimit.Limit = 0
+				if total, terr := svc.ForgetScope(ctx, noLimit); terr == nil {
+					uncapped = total
+				}
+			}
+			if uncapped != capped {
+				fmt.Printf("%d memories match; %d would be removed (%s, --limit %d). Nothing deleted — pass --yes to apply.\n",
+					uncapped, capped, mode, opts.Limit)
+			} else {
+				fmt.Printf("%d memories match (%s). Nothing deleted — pass --yes to apply.\n", capped, mode)
+			}
 			return
+		}
+
+		n, err := svc.ForgetScope(ctx, opts)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "forget error: %v\n", err)
+			os.Exit(1)
 		}
 		fmt.Printf("%d memories removed (%s).\n", n, mode)
 		return
@@ -101,20 +124,31 @@ func runForget(args []string) {
 	fmt.Printf("Soft-deleted memory %s\n", id)
 }
 
+// maxAgeDays bounds --older-than. Past this a time.Duration overflows int64 and
+// wraps negative, which turns `now - age` into a cutoff in the FUTURE that
+// matches every row — so `--older-than 106752d --hard --yes` would delete the
+// whole corpus. The realistic way to hit it is a script passing epoch seconds
+// where days are expected. A century is beyond any retention policy; anything
+// larger is a typo, and a typo on a destructive command must be rejected, not
+// silently reinterpreted.
+const maxAgeDays = 36500
+
 // parseAge accepts the durations a retention cut is actually expressed in.
 // time.ParseDuration tops out at hours, so days get their own suffix.
 func parseAge(s string) (time.Duration, error) {
 	s = strings.TrimSpace(s)
 	if raw, ok := strings.CutSuffix(s, "d"); ok {
 		days, err := strconv.Atoi(raw)
-		if err != nil || days < 0 {
-			return 0, fmt.Errorf("invalid age %q: want something like 60d", s)
+		if err != nil || days <= 0 || days > maxAgeDays {
+			return 0, fmt.Errorf("invalid age %q: want 1d..%dd", s, maxAgeDays)
 		}
 		return time.Duration(days) * 24 * time.Hour, nil
 	}
 	d, err := time.ParseDuration(s)
-	if err != nil || d < 0 {
-		return 0, fmt.Errorf("invalid age %q: want something like 60d or 12h", s)
+	// A zero age puts the cutoff at now, silently matching everything — the same
+	// hazard as the overflow, reached by a much likelier typo.
+	if err != nil || d <= 0 || d > maxAgeDays*24*time.Hour {
+		return 0, fmt.Errorf("invalid age %q: want something like 60d or 12h (max %dd)", s, maxAgeDays)
 	}
 	return d, nil
 }

--- a/cmd/anchored/forget.go
+++ b/cmd/anchored/forget.go
@@ -124,13 +124,10 @@ func runForget(args []string) {
 	fmt.Printf("Soft-deleted memory %s\n", id)
 }
 
-// maxAgeDays bounds --older-than. Past this a time.Duration overflows int64 and
-// wraps negative, which turns `now - age` into a cutoff in the FUTURE that
-// matches every row — so `--older-than 106752d --hard --yes` would delete the
-// whole corpus. The realistic way to hit it is a script passing epoch seconds
-// where days are expected. A century is beyond any retention policy; anything
-// larger is a typo, and a typo on a destructive command must be rejected, not
-// silently reinterpreted.
+// maxAgeDays bounds --older-than. Beyond it a time.Duration overflows int64 and
+// wraps negative, putting the cutoff in the FUTURE where it matches every row —
+// on a --hard run that deletes the corpus. A century exceeds any retention
+// policy, so anything larger is a typo and must be rejected, not reinterpreted.
 const maxAgeDays = 36500
 
 // parseAge accepts the durations a retention cut is actually expressed in.

--- a/cmd/anchored/forget_age_test.go
+++ b/cmd/anchored/forget_age_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// parseAge feeds a cutoff into a destructive command, so every input that does
+// NOT error has to produce a cutoff in the past. The overflow case is the one
+// that matters: time.Duration is int64 nanoseconds, so a large enough day count
+// wraps negative and `now.Add(-age)` lands in the FUTURE, where `created_at <
+// cutoff` matches the entire corpus.
+func TestParseAgeRejectsAnythingThatWouldMatchEverything(t *testing.T) {
+	rejected := []struct {
+		in  string
+		why string
+	}{
+		{"106752d", "overflows int64 nanoseconds and wraps to a future cutoff"},
+		{"9999999999d", "epoch seconds pasted where days were expected"},
+		{"0d", "cutoff at now matches every existing row"},
+		{"0h", "same, via the duration path"},
+		{"-60d", "negative age moves the cutoff forward"},
+		{"-12h", "negative duration moves the cutoff forward"},
+		{"", "empty"},
+		{"d", "no number"},
+		{"60", "no unit"},
+		{"sixty days", "not a duration"},
+		{"1e3d", "Atoi does not accept exponent notation"},
+	}
+	for _, tt := range rejected {
+		t.Run(tt.in, func(t *testing.T) {
+			if _, err := parseAge(tt.in); err == nil {
+				t.Errorf("parseAge(%q) accepted it — %s", tt.in, tt.why)
+			}
+		})
+	}
+}
+
+func TestParseAgeAcceptsRealRetentionCuts(t *testing.T) {
+	tests := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"1d", 24 * time.Hour},
+		{"60d", 60 * 24 * time.Hour},
+		{"36500d", 36500 * 24 * time.Hour},
+		{"12h", 12 * time.Hour},
+		{"90m", 90 * time.Minute},
+		{"  60d  ", 60 * 24 * time.Hour},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := parseAge(tt.in)
+			if err != nil {
+				t.Fatalf("parseAge(%q) errored: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Errorf("parseAge(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// The property that actually protects the corpus: whatever parseAge accepts,
+// subtracting it from now must land strictly in the past.
+func TestParseAgeAcceptedValuesAlwaysYieldAPastCutoff(t *testing.T) {
+	now := time.Now().UTC()
+	for _, in := range []string{"1d", "60d", "36500d", "12h", "1s", "1ns"} {
+		age, err := parseAge(in)
+		if err != nil {
+			continue
+		}
+		if cutoff := now.Add(-age); !cutoff.Before(now) {
+			t.Errorf("parseAge(%q) = %v produced cutoff %v, which is not before %v",
+				in, age, cutoff, now)
+		}
+	}
+}

--- a/cmd/anchored/helpers.go
+++ b/cmd/anchored/helpers.go
@@ -143,8 +143,14 @@ func reorderArgsForFlag(fs *flag.FlagSet, args []string) []string {
 		}
 		name := strings.TrimLeft(a, "-")
 		f := fs.Lookup(name)
-		_, isBool := f.Value.(boolFlag)
-		if isBool || f == nil {
+		if f == nil {
+			// Unregistered flag — `--help` is the common one. Pass it through
+			// untouched and let fs.Parse report it. Reading f.Value first would
+			// dereference nil and take the whole process down.
+			flagArgs = append(flagArgs, a)
+			continue
+		}
+		if _, isBool := f.Value.(boolFlag); isBool {
 			flagArgs = append(flagArgs, a)
 		} else if i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
 			flagArgs = append(flagArgs, a, args[i+1])

--- a/cmd/anchored/helpers_reorder_test.go
+++ b/cmd/anchored/helpers_reorder_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"reflect"
+	"testing"
+)
+
+func newReorderFlagSet() *flag.FlagSet {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.String("category", "", "a string flag")
+	fs.Bool("global", false, "a bool flag")
+	return fs
+}
+
+// An unregistered flag must not take the process down. `anchored search --help`
+// hit exactly this: fs.Lookup returns nil for --help, and reading f.Value before
+// the nil check panicked with SIGSEGV on every subcommand that reorders args.
+func TestReorderArgsForFlagSurvivesUnknownFlag(t *testing.T) {
+	for _, args := range [][]string{
+		{"--help"},
+		{"-h"},
+		{"query text", "--help"},
+		{"--nope", "value", "query text"},
+	} {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("panicked on %v: %v", args, r)
+				}
+			}()
+			reorderArgsForFlag(newReorderFlagSet(), args)
+		}()
+	}
+}
+
+func TestReorderArgsForFlagKeepsKnownFlagBehavior(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "string flag pulls its value ahead of the positional",
+			in:   []string{"query text", "--category", "fact"},
+			want: []string{"--category", "fact", "query text"},
+		},
+		{
+			name: "bool flag does not consume the next arg",
+			in:   []string{"query text", "--global"},
+			want: []string{"--global", "query text"},
+		},
+		{
+			name: "string flag with no value gets an empty assignment",
+			in:   []string{"--category"},
+			want: []string{"--category="},
+		},
+		{
+			name: "explicit assignment passes through",
+			in:   []string{"--category=fact", "query text"},
+			want: []string{"--category=fact", "query text"},
+		},
+		{
+			name: "unknown flag is passed through for fs.Parse to report",
+			in:   []string{"--help", "query text"},
+			want: []string{"--help", "query text"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := reorderArgsForFlag(newReorderFlagSet(), tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("reorderArgsForFlag(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/anchored/hook_posttooluse.go
+++ b/cmd/anchored/hook_posttooluse.go
@@ -15,6 +15,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/jholhewres/anchored/pkg/config"
 	ctxpkg "github.com/jholhewres/anchored/pkg/context"
 	"github.com/jholhewres/anchored/pkg/debuglog"
 	"github.com/jholhewres/anchored/pkg/hookroute"
@@ -125,6 +126,19 @@ func runHookPostToolUse(args []string) {
 	runPostToolUseWithIO(*configPath, *sessionIDFlag, *cwdFlag, bytes.NewReader(content), os.Stdout, dlog)
 }
 
+// artifactCaptureEnabled reports whether tool output should be indexed into
+// content_chunks.
+//
+// This MUST track the flag that gates the Evictor. Chunks are written with a
+// 72h TTL, but the Evictor that acts on that TTL is constructed only inside the
+// context optimizer (pkg/context/optimizer.go, wired from serve.go behind this
+// same flag). Capturing while the optimizer is off therefore writes rows that
+// nothing ever reclaims: on one machine that left 23k expired chunks, the
+// oldest 78 days past a 72h TTL, holding ~300 MB — over half the database.
+func artifactCaptureEnabled(cfg *config.Config) bool {
+	return cfg != nil && cfg.ContextOptimizer.Enabled
+}
+
 // runPostToolUseWithIO wires the DB / artifact-capture / working-set
 // collaborators and runs the recording core against the given stdin/stdout. It
 // is split from runHookPostToolUse so the Cursor afterFileEdit path can reuse
@@ -143,9 +157,13 @@ func runPostToolUseWithIO(configPath, sessionIDFlag, cwdFlag string, stdin io.Re
 	// InsertChunk uses prepared statements, so PrepareStatements MUST run
 	// first; on failure we leave capture nil and fall back to the event-only
 	// path rather than risk a nil-statement panic in the fail-safe hook.
+	//
+	// Capture is gated on the same flag as eviction — see artifactCaptureEnabled.
 	var capture func(projectID, sessionID, artifactType, sourceTool, sourceLabel, content string) (string, error)
 	artStore := ctxpkg.NewStore(hc.db, nil)
-	if perr := artStore.PrepareStatements(); perr != nil {
+	if !artifactCaptureEnabled(hc.cfg) {
+		dlog.Event("hook.posttooluse", map[string]any{"stage": "artifact_capture_disabled"})
+	} else if perr := artStore.PrepareStatements(); perr != nil {
 		slog.Warn("posttooluse: prepare statements failed; artifact capture disabled", "error", perr)
 		dlog.Event("hook.posttooluse", map[string]any{"stage": "artifact_prepare_failed", "error": perr.Error()})
 	} else {

--- a/cmd/anchored/hook_posttooluse.go
+++ b/cmd/anchored/hook_posttooluse.go
@@ -129,12 +129,10 @@ func runHookPostToolUse(args []string) {
 // artifactCaptureEnabled reports whether tool output should be indexed into
 // content_chunks.
 //
-// This MUST track the flag that gates the Evictor. Chunks are written with a
-// 72h TTL, but the Evictor that acts on that TTL is constructed only inside the
-// context optimizer (pkg/context/optimizer.go, wired from serve.go behind this
-// same flag). Capturing while the optimizer is off therefore writes rows that
-// nothing ever reclaims: on one machine that left 23k expired chunks, the
-// oldest 78 days past a 72h TTL, holding ~300 MB — over half the database.
+// This MUST track the flag that gates the Evictor: chunks are written with a
+// TTL, but the Evictor that acts on it is constructed only inside the context
+// optimizer (pkg/context/optimizer.go, wired from serve.go behind this same
+// flag). Capturing while the optimizer is off writes rows nothing reclaims.
 func artifactCaptureEnabled(cfg *config.Config) bool {
 	return cfg != nil && cfg.ContextOptimizer.Enabled
 }

--- a/cmd/anchored/hook_posttooluse_capture_gate_test.go
+++ b/cmd/anchored/hook_posttooluse_capture_gate_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/jholhewres/anchored/pkg/config"
+)
+
+// Capture writes chunks with a 72h TTL, but the Evictor that enforces that TTL
+// is built only inside the context optimizer. If capture is not gated on the
+// same flag, disabling the optimizer disables the cleanup while leaving the
+// writes on — the exact asymmetry that let content_chunks reach ~300 MB of
+// expired rows on a real database.
+func TestArtifactCaptureEnabledTracksTheEvictionFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.Config
+		want bool
+	}{
+		{
+			name: "optimizer on — capture and eviction both run",
+			cfg:  cfgWithOptimizer(true),
+			want: true,
+		},
+		{
+			name: "optimizer off — capture must stop, since nothing evicts",
+			cfg:  cfgWithOptimizer(false),
+			want: false,
+		},
+		{
+			name: "nil config — no basis to assume eviction runs",
+			cfg:  nil,
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := artifactCaptureEnabled(tt.cfg); got != tt.want {
+				t.Errorf("artifactCaptureEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func cfgWithOptimizer(enabled bool) *config.Config {
+	c := &config.Config{}
+	c.ContextOptimizer.Enabled = enabled
+	return c
+}

--- a/pkg/dream/analyzer.go
+++ b/pkg/dream/analyzer.go
@@ -66,14 +66,23 @@ func (a *DreamAnalyzer) Analyze(ctx context.Context) (*DreamReport, error) {
 
 	for rows.Next() {
 		var m memInfo
-		if err := rows.Scan(&m.id, &m.content, &m.contentHash, &m.projectID, &m.createdAt); err != nil {
+		// content_hash is nullable: rows predating the hashing backfill, and
+		// legacy revisions, carry NULL. Scanning that into a plain string fails
+		// the whole run. The empty case is already excluded from hash grouping
+		// below, so unhashed memories simply skip exact dedup.
+		var hash sql.NullString
+		if err := rows.Scan(&m.id, &m.content, &hash, &m.projectID, &m.createdAt); err != nil {
 			return nil, fmt.Errorf("scan memory: %w", err)
 		}
+		m.contentHash = hash.String
 		idx := len(memories)
 		memories = append(memories, m)
 		if m.contentHash != "" {
 			hashGroups[m.contentHash] = append(hashGroups[m.contentHash], idx)
 		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate memories: %w", err)
 	}
 
 	report.TotalMemories = len(memories)

--- a/pkg/dream/analyzer_null_hash_test.go
+++ b/pkg/dream/analyzer_null_hash_test.go
@@ -1,0 +1,68 @@
+package dream
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// content_hash is nullable, and rows predating the hashing backfill carry NULL.
+// Scanning that into a plain string aborted the entire dream run with
+// "converting NULL to string is unsupported", so a single unhashed memory
+// disabled consolidation for the whole corpus.
+func TestAnalyzeToleratesNullContentHash(t *testing.T) {
+	db, err := sql.Open("sqlite3", filepath.Join(t.TempDir(), "dream.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec(`CREATE TABLE memories (
+		id TEXT PRIMARY KEY,
+		project_id TEXT,
+		category TEXT,
+		content TEXT,
+		content_hash TEXT,
+		keywords TEXT,
+		embedding BLOB,
+		created_at DATETIME,
+		deleted_at DATETIME
+	)`); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+
+	rows := []struct {
+		id, content string
+		hash        any
+	}{
+		{"m-null", "memoria sem hash", nil},
+		{"m-dup-a", "conteudo repetido", "hash-repetido"},
+		{"m-dup-b", "conteudo repetido", "hash-repetido"},
+		{"m-solo", "conteudo unico", "hash-unico"},
+	}
+	for _, r := range rows {
+		if _, err := db.Exec(
+			`INSERT INTO memories (id, content, content_hash, created_at) VALUES (?, ?, ?, '2026-01-01 00:00:00')`,
+			r.id, r.content, r.hash,
+		); err != nil {
+			t.Fatalf("insert %s: %v", r.id, err)
+		}
+	}
+
+	report, err := NewAnalyzer(db, nil, DreamConfig{}, nil).Analyze(context.Background())
+	if err != nil {
+		t.Fatalf("Analyze aborted on a NULL content_hash: %v", err)
+	}
+	if report.TotalMemories != 4 {
+		t.Errorf("TotalMemories = %d, want 4", report.TotalMemories)
+	}
+	// The unhashed row must be skipped by exact dedup, not treated as matching
+	// the other unhashed rows — collapsing them under "" would be worse than
+	// the crash.
+	if report.ExactDupes != 1 {
+		t.Errorf("ExactDupes = %d, want 1 (only the real hash pair)", report.ExactDupes)
+	}
+}

--- a/pkg/memory/embedding_vector_restamp_test.go
+++ b/pkg/memory/embedding_vector_restamp_test.go
@@ -1,0 +1,123 @@
+package memory
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// A vector row whose content_hash no longer matches its revision is stale. If
+// PutEmbeddingVector skips it instead of overwriting, the stamp becomes
+// permanent: the upsert reports success, writes nothing, and the generation can
+// never satisfy the coverage its activation check demands — so the embedding
+// worker re-embeds the same revision forever and semantic search stays off.
+func TestPutEmbeddingVectorRestampsStaleRow(t *testing.T) {
+	store, err := NewSQLiteStore(
+		filepath.Join(t.TempDir(), "restamp.db"),
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	identity := EmbeddingIdentity{
+		Provider: "onnx", Model: "m", ModelRevision: "r1",
+		Dimensions: 3, Normalization: "l2",
+	}
+	spaceID := identity.SemanticSpaceID()
+
+	const memID = "mem-restamp"
+	if err := store.Save(ctx, Memory{
+		ID:        memID,
+		Category:  "fact",
+		Content:   "conteudo que sera reembeddado",
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("save memory: %v", err)
+	}
+
+	var revisionID, revisionHash string
+	if err := store.db.QueryRowContext(ctx,
+		"SELECT revision_id, content_hash FROM memory_revisions WHERE memory_id = ?", memID,
+	).Scan(&revisionID, &revisionHash); err != nil {
+		t.Fatalf("read revision: %v", err)
+	}
+
+	if _, err := store.db.ExecContext(ctx,
+		`INSERT INTO embedding_generations
+		   (generation_id, semantic_space_id, provider, model, model_revision,
+		    dimensions, normalization, state, snapshot_at, created_at)
+		 VALUES ('gen-restamp', ?, 'onnx', 'm', 'r1', 3, 'l2',
+		         'building', 0, 0)`, spaceID,
+	); err != nil {
+		t.Fatalf("seed generation: %v", err)
+	}
+
+	// A row written before the revision's hash was known — exactly the shape
+	// found in production, where legacy revisions carried a NULL content_hash.
+	if _, err := store.db.ExecContext(ctx,
+		`INSERT INTO memory_embedding_vectors
+		   (revision_id, memory_id, generation_id, semantic_space_id, purpose,
+		    provider, model, model_revision, dimensions, normalization,
+		    content_hash, embedding, embedded_at)
+		 VALUES (?, ?, 'gen-restamp', ?, 'document', 'onnx', 'm',
+		         'r1', 3, 'l2', '', X'00', 0)`,
+		revisionID, memID, spaceID,
+	); err != nil {
+		t.Fatalf("seed stale vector: %v", err)
+	}
+
+	err = store.PutEmbeddingVector(ctx, EmbeddingVectorRecord{
+		RevisionID:      revisionID,
+		MemoryID:        memID,
+		GenerationID:    "gen-restamp",
+		SemanticSpaceID: spaceID,
+		Purpose:         EmbeddingPurposeDocument,
+		Identity:        identity,
+		ContentHash:     revisionHash,
+		Vector:          []float32{0.1, 0.2, 0.3},
+		EmbeddedAt:      time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("PutEmbeddingVector: %v", err)
+	}
+
+	var got string
+	if err := store.db.QueryRowContext(ctx,
+		`SELECT content_hash FROM memory_embedding_vectors
+		 WHERE revision_id = ? AND generation_id = 'gen-restamp' AND purpose = 'document'`,
+		revisionID,
+	).Scan(&got); err != nil {
+		t.Fatalf("read vector: %v", err)
+	}
+	if got != revisionHash {
+		t.Fatalf("stale content_hash survived the upsert: got %q, want %q — "+
+			"the write was silently skipped, which is what strands a generation "+
+			"in 'building' forever", got, revisionHash)
+	}
+
+	// And the row must now satisfy the very predicate activation checks.
+	var missing int
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*)
+		FROM memories m
+		JOIN memory_revisions r ON r.revision_id = m.current_revision_id
+		WHERE m.deleted_at IS NULL AND r.is_tombstone = FALSE
+		  AND NOT EXISTS (
+			SELECT 1 FROM memory_embedding_vectors v
+			WHERE v.revision_id = r.revision_id
+			  AND v.generation_id = 'gen-restamp'
+			  AND v.purpose = 'document'
+			  AND v.content_hash = r.content_hash)`,
+	).Scan(&missing); err != nil {
+		t.Fatalf("coverage check: %v", err)
+	}
+	if missing != 0 {
+		t.Errorf("coverage still reports %d revision(s) missing after restamp", missing)
+	}
+}

--- a/pkg/memory/embedding_vector_restamp_test.go
+++ b/pkg/memory/embedding_vector_restamp_test.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"log/slog"
@@ -89,17 +90,25 @@ func TestPutEmbeddingVectorRestampsStaleRow(t *testing.T) {
 	}
 
 	var got string
+	var gotBlob []byte
 	if err := store.db.QueryRowContext(ctx,
-		`SELECT content_hash FROM memory_embedding_vectors
+		`SELECT content_hash, embedding FROM memory_embedding_vectors
 		 WHERE revision_id = ? AND generation_id = 'gen-restamp' AND purpose = 'document'`,
 		revisionID,
-	).Scan(&got); err != nil {
+	).Scan(&got, &gotBlob); err != nil {
 		t.Fatalf("read vector: %v", err)
 	}
 	if got != revisionHash {
 		t.Fatalf("stale content_hash survived the upsert: got %q, want %q — "+
 			"the write was silently skipped, which is what strands a generation "+
 			"in 'building' forever", got, revisionHash)
+	}
+	// The hash alone is not enough: a regression that restamps the hash but drops
+	// `embedding = excluded.embedding` would leave the stale vector in place and
+	// still pass the coverage check, which is a worse failure than the original.
+	wantBlob := float32sToBlob([]float32{0.1, 0.2, 0.3})
+	if !bytes.Equal(gotBlob, wantBlob) {
+		t.Errorf("embedding blob was not replaced: got %x, want %x", gotBlob, wantBlob)
 	}
 
 	// And the row must now satisfy the very predicate activation checks.

--- a/pkg/memory/hybrid_search.go
+++ b/pkg/memory/hybrid_search.go
@@ -99,11 +99,7 @@ func (h *HybridSearcher) Search(ctx context.Context, query string, opts ...Searc
 		searchOpts = opts[0]
 	}
 	cfg := h.config
-	// The per-call option wins; the configured value is only the default for
-	// callers that do not ask. Reading cfg unconditionally made SearchOptions
-	// .MaxResults dead weight: `anchored search --limit 100` came back with
-	// search.max_results rows, and no caller could ever look deeper than the
-	// config allowed.
+	// The per-call option wins; the config value is only the default.
 	maxResults := searchOpts.MaxResults
 	if maxResults <= 0 {
 		maxResults = cfg.MaxResults

--- a/pkg/memory/hybrid_search.go
+++ b/pkg/memory/hybrid_search.go
@@ -99,7 +99,15 @@ func (h *HybridSearcher) Search(ctx context.Context, query string, opts ...Searc
 		searchOpts = opts[0]
 	}
 	cfg := h.config
-	maxResults := cfg.MaxResults
+	// The per-call option wins; the configured value is only the default for
+	// callers that do not ask. Reading cfg unconditionally made SearchOptions
+	// .MaxResults dead weight: `anchored search --limit 100` came back with
+	// search.max_results rows, and no caller could ever look deeper than the
+	// config allowed.
+	maxResults := searchOpts.MaxResults
+	if maxResults <= 0 {
+		maxResults = cfg.MaxResults
+	}
 	if maxResults <= 0 {
 		maxResults = 20
 	}

--- a/pkg/memory/hybrid_search_limit_test.go
+++ b/pkg/memory/hybrid_search_limit_test.go
@@ -1,0 +1,82 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// SearchOptions.MaxResults must win over the configured default. Reading the
+// config unconditionally made the per-call option dead weight: `anchored search
+// --limit 100` returned search.max_results rows, and nothing could look deeper
+// than the config allowed.
+var distinctWords = []string{
+	"postgres", "sqlite", "docker", "kubernetes", "redis", "kafka", "nginx",
+	"terraform", "ansible", "prometheus", "grafana", "vault", "consul", "etcd",
+	"rabbitmq", "elastic", "kibana", "jenkins", "gitlab", "argocd",
+}
+
+func TestHybridSearchHonorsPerCallLimit(t *testing.T) {
+	store, err := NewSQLiteStore(
+		filepath.Join(t.TempDir(), "limit.db"),
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+	ctx := context.Background()
+
+	// Every memory shares the query token but is otherwise distinct, so the
+	// near-duplicate merge on the save path does not collapse them.
+	for i := range 40 {
+		if err := store.Save(ctx, Memory{
+			ID:       fmt.Sprintf("mem-%02d", i),
+			Category: "fact",
+			Content: fmt.Sprintf(
+				"alpha registro %d sobre %s com detalhe %d e contexto proprio",
+				i, distinctWords[i%len(distinctWords)], i*7919),
+			CreatedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
+		}); err != nil {
+			t.Fatalf("seed %d: %v", i, err)
+		}
+	}
+
+	cfg := DefaultHybridSearchConfig()
+	// Deliberately tiny: the test asks for more than this and checks the
+	// per-call value wins. It cannot assert an exact count — MMR without a
+	// vector cache diversifies down on its own — so it asserts the config
+	// ceiling no longer binds.
+	cfg.MaxResults = 2
+	h := NewHybridSearcher(store, nil, nil, nil, cfg, nil, nil,
+		slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	t.Run("per-call limit overrides a smaller config default", func(t *testing.T) {
+		got, err := h.Search(ctx, "alpha", SearchOptions{MaxResults: 25})
+		if err != nil {
+			t.Fatalf("search: %v", err)
+		}
+		if len(got) <= cfg.MaxResults {
+			t.Errorf("got %d results, want more than the configured %d — "+
+				"the per-call limit was ignored", len(got), cfg.MaxResults)
+		}
+		if len(got) > 25 {
+			t.Errorf("got %d results, want at most the requested 25", len(got))
+		}
+	})
+
+	t.Run("config default applies when the caller does not ask", func(t *testing.T) {
+		got, err := h.Search(ctx, "alpha", SearchOptions{})
+		if err != nil {
+			t.Fatalf("search: %v", err)
+		}
+		if len(got) > cfg.MaxResults {
+			t.Errorf("got %d results, want at most the configured %d", len(got), cfg.MaxResults)
+		}
+	})
+}

--- a/pkg/memory/service.go
+++ b/pkg/memory/service.go
@@ -486,18 +486,8 @@ func (s *Service) Restore(ctx context.Context, id string) error {
 	return nil
 }
 
-func (s *Service) ForgetByScope(ctx context.Context, projectID, category, source string, hard bool) (int, error) {
-	return s.ForgetScope(ctx, DeleteScopeOptions{
-		ProjectID: projectID,
-		Category:  category,
-		Source:    source,
-		Hard:      hard,
-	})
-}
-
-// ForgetScope removes every memory matching the scope. With DryRun it only
-// reports how many would match, which is what the CLI defaults to: a prune
-// that spans an entire imported category is not something to run blind.
+// ForgetScope removes every memory matching the scope; with DryRun it only
+// counts them.
 func (s *Service) ForgetScope(ctx context.Context, opts DeleteScopeOptions) (int, error) {
 	return s.store.DeleteByScope(ctx, opts)
 }

--- a/pkg/memory/service.go
+++ b/pkg/memory/service.go
@@ -487,12 +487,19 @@ func (s *Service) Restore(ctx context.Context, id string) error {
 }
 
 func (s *Service) ForgetByScope(ctx context.Context, projectID, category, source string, hard bool) (int, error) {
-	return s.store.DeleteByScope(ctx, DeleteScopeOptions{
+	return s.ForgetScope(ctx, DeleteScopeOptions{
 		ProjectID: projectID,
 		Category:  category,
 		Source:    source,
 		Hard:      hard,
 	})
+}
+
+// ForgetScope removes every memory matching the scope. With DryRun it only
+// reports how many would match, which is what the CLI defaults to: a prune
+// that spans an entire imported category is not something to run blind.
+func (s *Service) ForgetScope(ctx context.Context, opts DeleteScopeOptions) (int, error) {
+	return s.store.DeleteByScope(ctx, opts)
 }
 
 func (s *Service) Stats(ctx context.Context) (*StoreStats, error) {

--- a/pkg/memory/sqlite_embedding_generation.go
+++ b/pkg/memory/sqlite_embedding_generation.go
@@ -122,6 +122,12 @@ func (s *SQLiteStore) PutEmbeddingVector(ctx context.Context, record EmbeddingVe
 	if storedMemoryID != record.MemoryID || storedHash.String != record.ContentHash {
 		return fmt.Errorf("embedding vector source does not match immutable revision")
 	}
+	// The check above already pins record.ContentHash to the revision's own
+	// hash, so the incoming stamp is authoritative: an existing row carrying a
+	// different one is stale and must be overwritten. Gating the upsert on the
+	// stored hash instead would make a stale stamp permanent — the write is
+	// skipped, no error is raised, and the generation can never reach the
+	// coverage its activation check demands.
 	_, err = tx.ExecContext(ctx, `INSERT INTO memory_embedding_vectors (
 		revision_id, memory_id, generation_id, semantic_space_id, purpose,
 		provider, model, model_revision, dimensions, normalization,
@@ -129,9 +135,9 @@ func (s *SQLiteStore) PutEmbeddingVector(ctx context.Context, record EmbeddingVe
 	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	ON CONFLICT(revision_id, generation_id, purpose) DO UPDATE SET
 		embedding = excluded.embedding,
-		embedded_at = excluded.embedded_at
-	WHERE memory_embedding_vectors.content_hash = excluded.content_hash
-	  AND memory_embedding_vectors.semantic_space_id = excluded.semantic_space_id`,
+		embedded_at = excluded.embedded_at,
+		content_hash = excluded.content_hash
+	WHERE memory_embedding_vectors.semantic_space_id = excluded.semantic_space_id`,
 		record.RevisionID, record.MemoryID, record.GenerationID, record.SemanticSpaceID,
 		record.Purpose, record.Identity.Provider, record.Identity.Model,
 		record.Identity.ModelRevision, record.Identity.Dimensions,

--- a/pkg/memory/sqlite_embedding_generation.go
+++ b/pkg/memory/sqlite_embedding_generation.go
@@ -128,7 +128,7 @@ func (s *SQLiteStore) PutEmbeddingVector(ctx context.Context, record EmbeddingVe
 	// stored hash instead would make a stale stamp permanent — the write is
 	// skipped, no error is raised, and the generation can never reach the
 	// coverage its activation check demands.
-	_, err = tx.ExecContext(ctx, `INSERT INTO memory_embedding_vectors (
+	result, err := tx.ExecContext(ctx, `INSERT INTO memory_embedding_vectors (
 		revision_id, memory_id, generation_id, semantic_space_id, purpose,
 		provider, model, model_revision, dimensions, normalization,
 		content_hash, embedding, embedded_at
@@ -145,6 +145,16 @@ func (s *SQLiteStore) PutEmbeddingVector(ctx context.Context, record EmbeddingVe
 		float32sToBlob(record.Vector), record.EmbeddedAt.UnixNano())
 	if err != nil {
 		return fmt.Errorf("store embedding vector: %w", err)
+	}
+	// The remaining semantic_space_id guard can still drop the upsert. Reporting
+	// that as success is the exact failure this function was fixed to stop: the
+	// coverage check would never be satisfied, the generation would never leave
+	// 'building', and the worker would re-embed the same revision forever with
+	// nothing in the logs. A dropped write is an error.
+	if n, raErr := result.RowsAffected(); raErr == nil && n == 0 {
+		return fmt.Errorf(
+			"embedding vector write dropped for revision %s: stored semantic space differs from %s",
+			record.RevisionID, record.SemanticSpaceID)
 	}
 	projected := false
 	if currentState == EmbeddingGenerationActive && record.Purpose == EmbeddingPurposeDocument {

--- a/pkg/memory/sqlite_embedding_generation.go
+++ b/pkg/memory/sqlite_embedding_generation.go
@@ -146,11 +146,8 @@ func (s *SQLiteStore) PutEmbeddingVector(ctx context.Context, record EmbeddingVe
 	if err != nil {
 		return fmt.Errorf("store embedding vector: %w", err)
 	}
-	// The remaining semantic_space_id guard can still drop the upsert. Reporting
-	// that as success is the exact failure this function was fixed to stop: the
-	// coverage check would never be satisfied, the generation would never leave
-	// 'building', and the worker would re-embed the same revision forever with
-	// nothing in the logs. A dropped write is an error.
+	// The semantic_space_id guard can still drop the upsert; reporting that as
+	// success would strand the generation in 'building' forever.
 	if n, raErr := result.RowsAffected(); raErr == nil && n == 0 {
 		return fmt.Errorf(
 			"embedding vector write dropped for revision %s: stored semantic space differs from %s",

--- a/pkg/memory/sqlite_store.go
+++ b/pkg/memory/sqlite_store.go
@@ -690,32 +690,55 @@ func (s *SQLiteStore) DeleteByScope(ctx context.Context, opts DeleteScopeOptions
 
 	where := strings.Join(conditions, " AND ")
 
-	// Resolve the target ids ONCE. Every downstream delete keys off this exact
-	// list, so a --limit run is deterministic (oldest first) instead of letting
-	// each subquery re-evaluate its own LIMIT over a shifting row set.
-	// A hard prune also reclaims rows already tombstoned; a soft one would have
-	// nothing left to do on them.
-	ids, err := s.resolveScopeIDs(ctx, where, args, opts.Limit, opts.Hard)
-	if err != nil {
-		return 0, err
-	}
-	if opts.DryRun || len(ids) == 0 {
+	if opts.DryRun {
+		ids, err := s.resolveScopeIDs(ctx, s.db, where, args, opts.Limit, opts.Hard)
+		if err != nil {
+			return 0, err
+		}
 		return len(ids), nil
-	}
-
-	if !opts.Hard {
-		return s.softDeleteIDsTemporal(ctx, ids)
 	}
 
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
-		return 0, fmt.Errorf("begin hard delete by scope: %w", err)
+		return 0, fmt.Errorf("begin delete by scope: %w", err)
 	}
 	defer tx.Rollback()
 
+	// Resolve INSIDE the transaction. _txlock=immediate takes the write lock at
+	// BEGIN, so nothing can re-scope a row between the resolve and the delete;
+	// resolving outside would let a concurrent anchored_update move a memory to
+	// another category and still have it deleted under the old one.
+	// Resolving once (rather than per statement) also makes --limit
+	// deterministic: every delete keys off this exact oldest-first list instead
+	// of each subquery re-evaluating its own LIMIT over a shifting row set.
+	// A hard prune reclaims rows already tombstoned; a soft one has nothing
+	// left to do on them.
+	ids, err := s.resolveScopeIDs(ctx, tx, where, args, opts.Limit, opts.Hard)
+	if err != nil {
+		return 0, err
+	}
+	if len(ids) == 0 {
+		return 0, nil
+	}
+
+	if !opts.Hard {
+		n, err := s.softDeleteIDsTx(ctx, tx, ids)
+		if err != nil {
+			return 0, err
+		}
+		if err := tx.Commit(); err != nil {
+			return 0, fmt.Errorf("commit soft delete by scope: %w", err)
+		}
+		for _, id := range ids {
+			s.cache.Remove(id)
+		}
+		return n, nil
+	}
+
 	// A temp table keeps the id list out of bound parameters: SQLite caps those
 	// (SQLITE_MAX_VARIABLE_NUMBER) well below the tens of thousands of rows an
-	// import-wide prune touches.
+	// import-wide prune touches. Temp tables are per-connection, and the
+	// transaction owns this one's lifetime.
 	if err := stageScopeTargets(ctx, tx, ids); err != nil {
 		return 0, err
 	}
@@ -724,26 +747,33 @@ func (s *SQLiteStore) DeleteByScope(ctx context.Context, opts DeleteScopeOptions
 	// by the memories_fts_delete trigger, and memory_embedding_vectors cascades
 	// off memory_revisions (FK ON DELETE CASCADE, with _foreign_keys=on in the
 	// DSN) — so revisions must be deleted before memories for it to fire.
+	// dream_actions references memories twice; both columns need clearing, or a
+	// scope-wide prune leaves one orphan per action it was party to.
 	satellites := []struct{ table, column string }{
 		{"memory_processing_jobs", "memory_id"},
 		{"remote_outbox", "memory_id"},
 		{"memory_revisions", "memory_id"},
+		{"dream_actions", "memory_id"},
+		{"dream_actions", "related_memory_id"},
 	}
 	for _, sat := range satellites {
 		if _, err := tx.ExecContext(ctx,
-			"DELETE FROM "+sat.table+" WHERE "+sat.column+" IN (SELECT id FROM scope_delete_targets)",
+			"DELETE FROM "+sat.table+" WHERE "+sat.column+" IN (SELECT id FROM temp.scope_delete_targets)",
 		); err != nil {
 			return 0, fmt.Errorf("hard delete %s by scope: %w", sat.table, err)
 		}
 	}
 
 	result, err := tx.ExecContext(ctx,
-		"DELETE FROM memories WHERE id IN (SELECT id FROM scope_delete_targets)",
+		"DELETE FROM memories WHERE id IN (SELECT id FROM temp.scope_delete_targets)",
 	)
 	if err != nil {
 		return 0, fmt.Errorf("hard delete by scope: %w", err)
 	}
 	n, _ := result.RowsAffected()
+	if _, err := tx.ExecContext(ctx, "DROP TABLE IF EXISTS temp.scope_delete_targets"); err != nil {
+		return 0, fmt.Errorf("drop scope target table: %w", err)
+	}
 	if err := tx.Commit(); err != nil {
 		return 0, fmt.Errorf("commit hard delete by scope: %w", err)
 	}
@@ -753,16 +783,23 @@ func (s *SQLiteStore) DeleteByScope(ctx context.Context, opts DeleteScopeOptions
 	return int(n), nil
 }
 
-func (s *SQLiteStore) resolveScopeIDs(ctx context.Context, where string, args []any, limit int, includeDeleted bool) ([]string, error) {
+// rowQuerier is satisfied by both *sql.DB and *sql.Tx, so the scope resolve can
+// run inside the deleting transaction (the only safe place for it) while the
+// dry-run path still reads without opening one.
+type rowQuerier interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
+func (s *SQLiteStore) resolveScopeIDs(ctx context.Context, q rowQuerier, where string, args []any, limit int, includeDeleted bool) ([]string, error) {
 	if !includeDeleted {
 		where = "deleted_at IS NULL AND " + where
 	}
-	q := "SELECT id FROM memories WHERE " + where + " ORDER BY created_at ASC"
+	query := "SELECT id FROM memories WHERE " + where + " ORDER BY created_at ASC"
 	if limit > 0 {
-		q += " LIMIT ?"
+		query += " LIMIT ?"
 		args = append(append([]any{}, args...), limit)
 	}
-	rows, err := s.db.QueryContext(ctx, q, args...)
+	rows, err := q.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list delete scope: %w", err)
 	}
@@ -781,23 +818,40 @@ func (s *SQLiteStore) resolveScopeIDs(ctx context.Context, where string, args []
 	return ids, nil
 }
 
+// stageScopeTargets materializes the id list in a temp table for the deletes to
+// join against. Temp tables are per-connection, so this cannot leak across
+// processes; DROP at the end keeps it from outliving the call on a pooled
+// connection. The name is qualified everywhere it is used, since an unqualified
+// reference would resolve to TEMP even if a main-schema table ever shared it.
 func stageScopeTargets(ctx context.Context, tx *sql.Tx, ids []string) error {
 	if _, err := tx.ExecContext(ctx,
-		"CREATE TEMP TABLE IF NOT EXISTS scope_delete_targets (id TEXT PRIMARY KEY)",
+		"DROP TABLE IF EXISTS temp.scope_delete_targets",
+	); err != nil {
+		return fmt.Errorf("reset scope target table: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		"CREATE TEMP TABLE scope_delete_targets (id TEXT PRIMARY KEY)",
 	); err != nil {
 		return fmt.Errorf("create scope target table: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx, "DELETE FROM scope_delete_targets"); err != nil {
-		return fmt.Errorf("reset scope target table: %w", err)
-	}
-	stmt, err := tx.PrepareContext(ctx, "INSERT INTO scope_delete_targets (id) VALUES (?)")
-	if err != nil {
-		return fmt.Errorf("prepare scope target insert: %w", err)
-	}
-	defer stmt.Close()
-	for _, id := range ids {
-		if _, err := stmt.ExecContext(ctx, id); err != nil {
-			return fmt.Errorf("stage scope target %s: %w", id, err)
+	// Batched multi-row VALUES: one round trip per batch instead of one per id
+	// turns an 11k-row prune from 11k statements into ~23.
+	const batch = 500
+	for start := 0; start < len(ids); start += batch {
+		end := min(start+batch, len(ids))
+		chunk := ids[start:end]
+		q := strings.Builder{}
+		q.WriteString("INSERT INTO temp.scope_delete_targets (id) VALUES ")
+		args := make([]any, 0, len(chunk))
+		for i, id := range chunk {
+			if i > 0 {
+				q.WriteString(",")
+			}
+			q.WriteString("(?)")
+			args = append(args, id)
+		}
+		if _, err := tx.ExecContext(ctx, q.String(), args...); err != nil {
+			return fmt.Errorf("stage scope targets: %w", err)
 		}
 	}
 	return nil

--- a/pkg/memory/sqlite_store.go
+++ b/pkg/memory/sqlite_store.go
@@ -679,70 +679,128 @@ func (s *SQLiteStore) DeleteByScope(ctx context.Context, opts DeleteScopeOptions
 		args = append(args, opts.Source)
 	}
 
+	if !opts.OlderThan.IsZero() {
+		conditions = append(conditions, "created_at < ?")
+		args = append(args, opts.OlderThan.UTC().Format("2006-01-02 15:04:05"))
+	}
+
 	if len(conditions) == 0 {
 		return 0, fmt.Errorf("at least one scope condition is required")
 	}
 
-	if opts.Hard {
-		where := strings.Join(conditions, " AND ")
-		rows, err := s.db.QueryContext(ctx, "SELECT id FROM memories WHERE "+where, args...)
-		if err != nil {
-			return 0, fmt.Errorf("list hard-delete scope: %w", err)
-		}
-		var ids []string
-		for rows.Next() {
-			var id string
-			if err := rows.Scan(&id); err != nil {
-				rows.Close()
-				return 0, err
-			}
-			ids = append(ids, id)
-		}
-		if err := rows.Close(); err != nil {
-			return 0, err
-		}
-		if err := rows.Err(); err != nil {
-			return 0, err
-		}
+	where := strings.Join(conditions, " AND ")
 
-		tx, err := s.db.BeginTx(ctx, nil)
-		if err != nil {
-			return 0, fmt.Errorf("begin hard delete by scope: %w", err)
-		}
-		defer tx.Rollback()
-		if _, err := tx.ExecContext(ctx,
-			"DELETE FROM memory_processing_jobs WHERE memory_id IN (SELECT id FROM memories WHERE "+where+")",
-			args...,
-		); err != nil {
-			return 0, fmt.Errorf("hard delete processing jobs by scope: %w", err)
-		}
-		if _, err := tx.ExecContext(ctx,
-			"DELETE FROM remote_outbox WHERE memory_id IN (SELECT id FROM memories WHERE "+where+")",
-			args...,
-		); err != nil {
-			return 0, fmt.Errorf("hard delete remote outbox by scope: %w", err)
-		}
-		if _, err := tx.ExecContext(ctx,
-			"DELETE FROM memory_revisions WHERE memory_id IN (SELECT id FROM memories WHERE "+where+")",
-			args...,
-		); err != nil {
-			return 0, fmt.Errorf("hard delete revision history by scope: %w", err)
-		}
-		result, err := tx.ExecContext(ctx, "DELETE FROM memories WHERE "+where, args...)
-		if err != nil {
-			return 0, fmt.Errorf("hard delete by scope: %w", err)
-		}
-		n, _ := result.RowsAffected()
-		if err := tx.Commit(); err != nil {
-			return 0, fmt.Errorf("commit hard delete by scope: %w", err)
-		}
-		for _, id := range ids {
-			s.cache.Remove(id)
-		}
-		return int(n), nil
+	// Resolve the target ids ONCE. Every downstream delete keys off this exact
+	// list, so a --limit run is deterministic (oldest first) instead of letting
+	// each subquery re-evaluate its own LIMIT over a shifting row set.
+	// A hard prune also reclaims rows already tombstoned; a soft one would have
+	// nothing left to do on them.
+	ids, err := s.resolveScopeIDs(ctx, where, args, opts.Limit, opts.Hard)
+	if err != nil {
+		return 0, err
+	}
+	if opts.DryRun || len(ids) == 0 {
+		return len(ids), nil
 	}
 
-	return s.softDeleteByScopeTemporal(ctx, strings.Join(conditions, " AND "), args)
+	if !opts.Hard {
+		return s.softDeleteIDsTemporal(ctx, ids)
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, fmt.Errorf("begin hard delete by scope: %w", err)
+	}
+	defer tx.Rollback()
+
+	// A temp table keeps the id list out of bound parameters: SQLite caps those
+	// (SQLITE_MAX_VARIABLE_NUMBER) well below the tens of thousands of rows an
+	// import-wide prune touches.
+	if err := stageScopeTargets(ctx, tx, ids); err != nil {
+		return 0, err
+	}
+
+	// Only the satellites that need an explicit delete. memories_fts is driven
+	// by the memories_fts_delete trigger, and memory_embedding_vectors cascades
+	// off memory_revisions (FK ON DELETE CASCADE, with _foreign_keys=on in the
+	// DSN) — so revisions must be deleted before memories for it to fire.
+	satellites := []struct{ table, column string }{
+		{"memory_processing_jobs", "memory_id"},
+		{"remote_outbox", "memory_id"},
+		{"memory_revisions", "memory_id"},
+	}
+	for _, sat := range satellites {
+		if _, err := tx.ExecContext(ctx,
+			"DELETE FROM "+sat.table+" WHERE "+sat.column+" IN (SELECT id FROM scope_delete_targets)",
+		); err != nil {
+			return 0, fmt.Errorf("hard delete %s by scope: %w", sat.table, err)
+		}
+	}
+
+	result, err := tx.ExecContext(ctx,
+		"DELETE FROM memories WHERE id IN (SELECT id FROM scope_delete_targets)",
+	)
+	if err != nil {
+		return 0, fmt.Errorf("hard delete by scope: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("commit hard delete by scope: %w", err)
+	}
+	for _, id := range ids {
+		s.cache.Remove(id)
+	}
+	return int(n), nil
+}
+
+func (s *SQLiteStore) resolveScopeIDs(ctx context.Context, where string, args []any, limit int, includeDeleted bool) ([]string, error) {
+	if !includeDeleted {
+		where = "deleted_at IS NULL AND " + where
+	}
+	q := "SELECT id FROM memories WHERE " + where + " ORDER BY created_at ASC"
+	if limit > 0 {
+		q += " LIMIT ?"
+		args = append(append([]any{}, args...), limit)
+	}
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("list delete scope: %w", err)
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
+func stageScopeTargets(ctx context.Context, tx *sql.Tx, ids []string) error {
+	if _, err := tx.ExecContext(ctx,
+		"CREATE TEMP TABLE IF NOT EXISTS scope_delete_targets (id TEXT PRIMARY KEY)",
+	); err != nil {
+		return fmt.Errorf("create scope target table: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, "DELETE FROM scope_delete_targets"); err != nil {
+		return fmt.Errorf("reset scope target table: %w", err)
+	}
+	stmt, err := tx.PrepareContext(ctx, "INSERT INTO scope_delete_targets (id) VALUES (?)")
+	if err != nil {
+		return fmt.Errorf("prepare scope target insert: %w", err)
+	}
+	defer stmt.Close()
+	for _, id := range ids {
+		if _, err := stmt.ExecContext(ctx, id); err != nil {
+			return fmt.Errorf("stage scope target %s: %w", id, err)
+		}
+	}
+	return nil
 }
 
 func (s *SQLiteStore) FindByContentHash(ctx context.Context, hash string, projectID *string) (*Memory, error) {

--- a/pkg/memory/sqlite_store.go
+++ b/pkg/memory/sqlite_store.go
@@ -735,10 +735,6 @@ func (s *SQLiteStore) DeleteByScope(ctx context.Context, opts DeleteScopeOptions
 		return n, nil
 	}
 
-	// A temp table keeps the id list out of bound parameters: SQLite caps those
-	// (SQLITE_MAX_VARIABLE_NUMBER) well below the tens of thousands of rows an
-	// import-wide prune touches. Temp tables are per-connection, and the
-	// transaction owns this one's lifetime.
 	if err := stageScopeTargets(ctx, tx, ids); err != nil {
 		return 0, err
 	}
@@ -834,8 +830,7 @@ func stageScopeTargets(ctx context.Context, tx *sql.Tx, ids []string) error {
 	); err != nil {
 		return fmt.Errorf("create scope target table: %w", err)
 	}
-	// Batched multi-row VALUES: one round trip per batch instead of one per id
-	// turns an 11k-row prune from 11k statements into ~23.
+	// Batched so an 11k-id prune is ~23 statements, not 11k.
 	const batch = 500
 	for start := 0; start < len(ids); start += batch {
 		end := min(start+batch, len(ids))

--- a/pkg/memory/sqlite_store_scope_test.go
+++ b/pkg/memory/sqlite_store_scope_test.go
@@ -11,16 +11,23 @@ import (
 )
 
 // satelliteTables are every memory-keyed table that must end up empty of a
-// pruned memory, whatever the mechanism. memory_processing_jobs, remote_outbox
-// and memory_revisions are deleted explicitly; memory_embedding_vectors is here
-// precisely because it is NOT — it rides the FK cascade off memory_revisions,
-// and this assertion is what proves that cascade actually fires.
-// memories_fts is absent: the memories_fts_delete trigger owns it.
-var satelliteTables = []string{
-	"memory_processing_jobs",
-	"remote_outbox",
-	"memory_revisions",
-	"memory_embedding_vectors",
+// pruned memory, whatever the mechanism. memory_processing_jobs, remote_outbox,
+// memory_revisions and dream_actions are deleted explicitly;
+// memory_embedding_vectors is here precisely because it is NOT — it rides the
+// FK cascade off memory_revisions, and this assertion is what proves that
+// cascade actually fires. memories_fts is absent: the memories_fts_delete
+// trigger owns it.
+//
+// Every table listed here MUST be populated by seedScopeMemory. A satellite the
+// seed never fills makes assertNoOrphans vacuously true for it, which reads as
+// coverage and is not.
+var satelliteTables = []struct{ table, column string }{
+	{"memory_processing_jobs", "memory_id"},
+	{"remote_outbox", "memory_id"},
+	{"memory_revisions", "memory_id"},
+	{"memory_embedding_vectors", "memory_id"},
+	{"dream_actions", "memory_id"},
+	{"dream_actions", "related_memory_id"},
 }
 
 func newScopeTestStore(t *testing.T) *SQLiteStore {
@@ -39,15 +46,32 @@ func newScopeTestStore(t *testing.T) *SQLiteStore {
 func seedScopeMemory(t *testing.T, s *SQLiteStore, id, category string, createdAt time.Time) {
 	t.Helper()
 	ctx := context.Background()
-	if err := s.Save(ctx, Memory{
+	// ProcessingJobs / RemoteOutbox are what put rows in those two satellites;
+	// a plain Save() leaves them empty and makes the orphan check vacuous.
+	if _, err := s.SaveTemporal(ctx, Memory{
 		ID:        id,
 		Category:  category,
 		Content:   "content for " + id,
 		Source:    "test-import",
 		CreatedAt: createdAt,
 		UpdatedAt: createdAt,
+	}, TemporalWriteOptions{
+		ProcessingJobs: []ProcessingJobSpec{{Kind: "embedding", Generation: "gen-test"}},
+		RemoteOutbox:   []RemoteOutboxSpec{{Remote: "remote-test", Payload: []byte(id)}},
 	}); err != nil {
 		t.Fatalf("seed memory %s: %v", id, err)
+	}
+
+	// dream_actions points at memories twice and, unlike memory_embedding_vectors,
+	// has NO foreign key on either column — nothing cascades, so the prune has to
+	// clear both explicitly. run_id is left NULL: its FK targets dream_runs and
+	// is irrelevant to what this test pins.
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO dream_actions (id, run_id, memory_id, related_memory_id, action_type, confidence, reason, proposed_at, status)
+		 VALUES ('act-'||?, NULL, ?, ?, 'dedup', 1.0, 'seeded', CURRENT_TIMESTAMP, 'proposed')`,
+		id, id, id,
+	); err != nil {
+		t.Fatalf("seed dream action for %s: %v", id, err)
 	}
 	if _, err := s.db.ExecContext(ctx,
 		`INSERT OR IGNORE INTO embedding_generations
@@ -93,11 +117,32 @@ func countRows(t *testing.T, db *sql.DB, query string) int {
 
 func assertNoOrphans(t *testing.T, s *SQLiteStore) {
 	t.Helper()
-	for _, table := range satelliteTables {
-		n := countRows(t, s.db,
-			"SELECT COUNT(*) FROM "+table+" WHERE memory_id NOT IN (SELECT id FROM memories)")
+	for _, sat := range satelliteTables {
+		// A satellite the seed never populated would pass trivially, so assert
+		// it is non-empty before the prune runs is not possible here — instead
+		// seedScopeMemory fills every one, and TestSeedFillsEverySatellite pins
+		// that contract.
+		n := countRows(t, s.db, "SELECT COUNT(*) FROM "+sat.table+
+			" WHERE "+sat.column+" IS NOT NULL AND "+sat.column+" NOT IN (SELECT id FROM memories)")
 		if n != 0 {
-			t.Errorf("%s left %d orphan row(s) after hard prune", table, n)
+			t.Errorf("%s.%s left %d orphan row(s) after hard prune", sat.table, sat.column, n)
+		}
+	}
+}
+
+// The orphan assertion is only worth anything if the seed actually writes to
+// every satellite it checks. This pins that: a satellite added to the list
+// without a matching seed write fails here rather than silently passing
+// assertNoOrphans for the rest of the file's lifetime.
+func TestSeedFillsEverySatellite(t *testing.T) {
+	s := newScopeTestStore(t)
+	seedScopeMemory(t, s, "seeded-1", "technical", time.Now().UTC().AddDate(0, 0, -10))
+	for _, sat := range satelliteTables {
+		n := countRows(t, s.db, "SELECT COUNT(*) FROM "+sat.table+
+			" WHERE "+sat.column+" = 'seeded-1'")
+		if n == 0 {
+			t.Errorf("seedScopeMemory writes nothing to %s.%s — assertNoOrphans is vacuous for it",
+				sat.table, sat.column)
 		}
 	}
 }
@@ -141,6 +186,11 @@ func TestDeleteByScopeDryRunTouchesNothing(t *testing.T) {
 	seedScopeMemory(t, s, "tech-2", "technical", old)
 
 	before := countRows(t, s.db, "SELECT COUNT(*) FROM memories")
+	satelliteBefore := map[string]int{}
+	for _, sat := range satelliteTables {
+		satelliteBefore[sat.table] = countRows(t, s.db, "SELECT COUNT(*) FROM "+sat.table)
+	}
+
 	n, err := s.DeleteByScope(ctx, DeleteScopeOptions{
 		Category: "technical", Hard: true, DryRun: true,
 	})
@@ -153,9 +203,13 @@ func TestDeleteByScopeDryRunTouchesNothing(t *testing.T) {
 	if after := countRows(t, s.db, "SELECT COUNT(*) FROM memories"); after != before {
 		t.Errorf("dry run changed the corpus: %d -> %d", before, after)
 	}
-	for _, table := range satelliteTables {
-		if got := countRows(t, s.db, "SELECT COUNT(*) FROM "+table); table == "memory_embedding_vectors" && got != 2 {
-			t.Errorf("dry run touched %s (got %d rows, want 2)", table, got)
+	// Every satellite must be untouched, not just the one the old assertion
+	// happened to name — the table filter used to sit inside this condition, so
+	// three of four iterations computed a count and threw it away.
+	for _, sat := range satelliteTables {
+		if got := countRows(t, s.db, "SELECT COUNT(*) FROM "+sat.table); got != satelliteBefore[sat.table] {
+			t.Errorf("dry run touched %s: %d rows, want %d",
+				sat.table, got, satelliteBefore[sat.table])
 		}
 	}
 }
@@ -219,5 +273,99 @@ func TestDeleteByScopeRequiresACondition(t *testing.T) {
 	s := newScopeTestStore(t)
 	if _, err := s.DeleteByScope(context.Background(), DeleteScopeOptions{Hard: true}); err == nil {
 		t.Fatal("an unscoped hard delete must be refused, not treated as delete-everything")
+	}
+}
+
+// The soft path was rewired by this change (softDeleteByScopeTemporal removed,
+// resolve moved into the caller's transaction) and every other test here runs
+// Hard:true. This covers the success case plus the two modifiers.
+func TestDeleteByScopeSoftTombstonesAndKeepsRows(t *testing.T) {
+	s := newScopeTestStore(t)
+	ctx := context.Background()
+	old := time.Now().UTC().AddDate(0, 0, -120)
+
+	seedScopeMemory(t, s, "soft-1", "technical", old)
+	seedScopeMemory(t, s, "soft-2", "technical", old)
+	seedScopeMemory(t, s, "keep-1", "decision", old)
+
+	n, err := s.DeleteByScope(ctx, DeleteScopeOptions{Category: "technical"})
+	if err != nil {
+		t.Fatalf("DeleteByScope: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("soft-deleted %d, want 2", n)
+	}
+	// A soft delete tombstones: the rows stay, they just leave the active view.
+	if got := countRows(t, s.db, "SELECT COUNT(*) FROM memories"); got != 3 {
+		t.Errorf("rows physically removed by a SOFT delete: %d left, want 3", got)
+	}
+	if got := countRows(t, s.db, "SELECT COUNT(*) FROM memories WHERE deleted_at IS NULL"); got != 1 {
+		t.Errorf("active memories = %d, want 1", got)
+	}
+}
+
+func TestDeleteByScopeSoftSkipsAlreadyTombstoned(t *testing.T) {
+	s := newScopeTestStore(t)
+	ctx := context.Background()
+	old := time.Now().UTC().AddDate(0, 0, -120)
+	seedScopeMemory(t, s, "soft-1", "technical", old)
+
+	if _, err := s.DeleteByScope(ctx, DeleteScopeOptions{Category: "technical"}); err != nil {
+		t.Fatalf("first soft delete: %v", err)
+	}
+	// includeDeleted is tied to Hard: a second soft pass must find nothing left
+	// to do, while a hard pass still reclaims the tombstone.
+	n, err := s.DeleteByScope(ctx, DeleteScopeOptions{Category: "technical"})
+	if err != nil {
+		t.Fatalf("second soft delete: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("second soft pass reported %d, want 0 — tombstones are not work", n)
+	}
+
+	hard, err := s.DeleteByScope(ctx, DeleteScopeOptions{Category: "technical", Hard: true})
+	if err != nil {
+		t.Fatalf("hard delete: %v", err)
+	}
+	if hard != 1 {
+		t.Errorf("hard pass reclaimed %d, want 1 — it must include tombstones", hard)
+	}
+	assertNoOrphans(t, s)
+}
+
+func TestDeleteByScopeSoftHonorsOlderThanAndLimit(t *testing.T) {
+	s := newScopeTestStore(t)
+	ctx := context.Background()
+
+	seedScopeMemory(t, s, "old-1", "plan", time.Now().UTC().AddDate(0, 0, -90))
+	seedScopeMemory(t, s, "old-2", "plan", time.Now().UTC().AddDate(0, 0, -80))
+	seedScopeMemory(t, s, "new-1", "plan", time.Now().UTC().AddDate(0, 0, -5))
+
+	n, err := s.DeleteByScope(ctx, DeleteScopeOptions{
+		Category:  "plan",
+		OlderThan: time.Now().UTC().AddDate(0, 0, -60),
+		Limit:     1,
+	})
+	if err != nil {
+		t.Fatalf("DeleteByScope: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("soft-deleted %d, want 1 (limit)", n)
+	}
+	var survivors []string
+	rows, err := s.db.Query("SELECT id FROM memories WHERE deleted_at IS NULL ORDER BY id")
+	if err != nil {
+		t.Fatalf("query survivors: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatal(err)
+		}
+		survivors = append(survivors, id)
+	}
+	if len(survivors) != 2 || survivors[0] != "new-1" || survivors[1] != "old-2" {
+		t.Errorf("survivors = %v, want [new-1 old-2] — the cap must take the oldest first", survivors)
 	}
 }

--- a/pkg/memory/sqlite_store_scope_test.go
+++ b/pkg/memory/sqlite_store_scope_test.go
@@ -276,9 +276,8 @@ func TestDeleteByScopeRequiresACondition(t *testing.T) {
 	}
 }
 
-// The soft path was rewired by this change (softDeleteByScopeTemporal removed,
-// resolve moved into the caller's transaction) and every other test here runs
-// Hard:true. This covers the success case plus the two modifiers.
+// Every other test in this file runs Hard:true, so this covers the soft path's
+// success case plus its two modifiers.
 func TestDeleteByScopeSoftTombstonesAndKeepsRows(t *testing.T) {
 	s := newScopeTestStore(t)
 	ctx := context.Background()

--- a/pkg/memory/sqlite_store_scope_test.go
+++ b/pkg/memory/sqlite_store_scope_test.go
@@ -1,0 +1,223 @@
+package memory
+
+import (
+	"context"
+	"database/sql"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// satelliteTables are every memory-keyed table that must end up empty of a
+// pruned memory, whatever the mechanism. memory_processing_jobs, remote_outbox
+// and memory_revisions are deleted explicitly; memory_embedding_vectors is here
+// precisely because it is NOT — it rides the FK cascade off memory_revisions,
+// and this assertion is what proves that cascade actually fires.
+// memories_fts is absent: the memories_fts_delete trigger owns it.
+var satelliteTables = []string{
+	"memory_processing_jobs",
+	"remote_outbox",
+	"memory_revisions",
+	"memory_embedding_vectors",
+}
+
+func newScopeTestStore(t *testing.T) *SQLiteStore {
+	t.Helper()
+	store, err := NewSQLiteStore(
+		filepath.Join(t.TempDir(), "scope.db"),
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+	return store
+}
+
+func seedScopeMemory(t *testing.T, s *SQLiteStore, id, category string, createdAt time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	if err := s.Save(ctx, Memory{
+		ID:        id,
+		Category:  category,
+		Content:   "content for " + id,
+		Source:    "test-import",
+		CreatedAt: createdAt,
+		UpdatedAt: createdAt,
+	}); err != nil {
+		t.Fatalf("seed memory %s: %v", id, err)
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO embedding_generations
+		   (generation_id, semantic_space_id, provider, model, model_revision,
+		    dimensions, normalization, state, snapshot_at, created_at)
+		 VALUES ('gen-test', 'space-test', 'onnx', 'test-model', 'r1', 3, 'l2',
+		         'building', 0, 0)`,
+	); err != nil {
+		t.Fatalf("seed embedding generation: %v", err)
+	}
+
+	// The vector hangs off the revision, not the memory, so it needs the real
+	// revision_id Save() minted — which is also exactly why deleting revisions
+	// is what reclaims vectors.
+	var revisionID string
+	if err := s.db.QueryRowContext(ctx,
+		"SELECT revision_id FROM memory_revisions WHERE memory_id = ? ORDER BY created_at DESC LIMIT 1", id,
+	).Scan(&revisionID); err != nil {
+		t.Fatalf("read revision for %s: %v", id, err)
+	}
+
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO memory_embedding_vectors
+		   (revision_id, memory_id, generation_id, semantic_space_id, purpose,
+		    provider, model, model_revision, dimensions, normalization,
+		    content_hash, embedding, embedded_at)
+		 VALUES (?, ?, 'gen-test', 'space-test', 'document', 'onnx', 'test-model',
+		         'r1', 3, 'l2', 'hash-'||?, X'00', 0)`,
+		revisionID, id, id,
+	); err != nil {
+		t.Fatalf("seed embedding vector for %s: %v", id, err)
+	}
+}
+
+func countRows(t *testing.T, db *sql.DB, query string) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(query).Scan(&n); err != nil {
+		t.Fatalf("count query %q: %v", query, err)
+	}
+	return n
+}
+
+func assertNoOrphans(t *testing.T, s *SQLiteStore) {
+	t.Helper()
+	for _, table := range satelliteTables {
+		n := countRows(t, s.db,
+			"SELECT COUNT(*) FROM "+table+" WHERE memory_id NOT IN (SELECT id FROM memories)")
+		if n != 0 {
+			t.Errorf("%s left %d orphan row(s) after hard prune", table, n)
+		}
+	}
+}
+
+func TestDeleteByScopeHardLeavesNoOrphans(t *testing.T) {
+	s := newScopeTestStore(t)
+	ctx := context.Background()
+	old := time.Now().UTC().AddDate(0, 0, -120)
+
+	seedScopeMemory(t, s, "tech-1", "technical", old)
+	seedScopeMemory(t, s, "tech-2", "technical", old)
+	seedScopeMemory(t, s, "keep-1", "decision", old)
+
+	n, err := s.DeleteByScope(ctx, DeleteScopeOptions{Category: "technical", Hard: true})
+	if err != nil {
+		t.Fatalf("DeleteByScope: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("removed %d memories, want 2", n)
+	}
+
+	assertNoOrphans(t, s)
+
+	if got := countRows(t, s.db, "SELECT COUNT(*) FROM memories"); got != 1 {
+		t.Errorf("memories left = %d, want 1", got)
+	}
+	// The survivor must keep its satellite rows: the prune has to be scoped,
+	// not a table-wide sweep that happens to pass the orphan check.
+	if got := countRows(t, s.db,
+		"SELECT COUNT(*) FROM memory_embedding_vectors WHERE memory_id = 'keep-1'"); got != 1 {
+		t.Errorf("survivor lost its embedding vector (got %d rows, want 1)", got)
+	}
+}
+
+func TestDeleteByScopeDryRunTouchesNothing(t *testing.T) {
+	s := newScopeTestStore(t)
+	ctx := context.Background()
+	old := time.Now().UTC().AddDate(0, 0, -120)
+
+	seedScopeMemory(t, s, "tech-1", "technical", old)
+	seedScopeMemory(t, s, "tech-2", "technical", old)
+
+	before := countRows(t, s.db, "SELECT COUNT(*) FROM memories")
+	n, err := s.DeleteByScope(ctx, DeleteScopeOptions{
+		Category: "technical", Hard: true, DryRun: true,
+	})
+	if err != nil {
+		t.Fatalf("DeleteByScope dry run: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("dry run counted %d, want 2", n)
+	}
+	if after := countRows(t, s.db, "SELECT COUNT(*) FROM memories"); after != before {
+		t.Errorf("dry run changed the corpus: %d -> %d", before, after)
+	}
+	for _, table := range satelliteTables {
+		if got := countRows(t, s.db, "SELECT COUNT(*) FROM "+table); table == "memory_embedding_vectors" && got != 2 {
+			t.Errorf("dry run touched %s (got %d rows, want 2)", table, got)
+		}
+	}
+}
+
+func TestDeleteByScopeOlderThanSparesRecent(t *testing.T) {
+	s := newScopeTestStore(t)
+	ctx := context.Background()
+
+	seedScopeMemory(t, s, "old-1", "plan", time.Now().UTC().AddDate(0, 0, -90))
+	seedScopeMemory(t, s, "new-1", "plan", time.Now().UTC().AddDate(0, 0, -5))
+
+	n, err := s.DeleteByScope(ctx, DeleteScopeOptions{
+		Category:  "plan",
+		Hard:      true,
+		OlderThan: time.Now().UTC().AddDate(0, 0, -60),
+	})
+	if err != nil {
+		t.Fatalf("DeleteByScope: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("removed %d memories, want 1", n)
+	}
+	var survivor string
+	if err := s.db.QueryRow("SELECT id FROM memories").Scan(&survivor); err != nil {
+		t.Fatalf("read survivor: %v", err)
+	}
+	if survivor != "new-1" {
+		t.Errorf("survivor = %q, want new-1", survivor)
+	}
+	assertNoOrphans(t, s)
+}
+
+func TestDeleteByScopeLimitDrainsOldestFirst(t *testing.T) {
+	s := newScopeTestStore(t)
+	ctx := context.Background()
+
+	seedScopeMemory(t, s, "oldest", "technical", time.Now().UTC().AddDate(0, 0, -300))
+	seedScopeMemory(t, s, "middle", "technical", time.Now().UTC().AddDate(0, 0, -200))
+	seedScopeMemory(t, s, "newest", "technical", time.Now().UTC().AddDate(0, 0, -100))
+
+	n, err := s.DeleteByScope(ctx, DeleteScopeOptions{
+		Category: "technical", Hard: true, Limit: 2,
+	})
+	if err != nil {
+		t.Fatalf("DeleteByScope: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("removed %d memories, want 2", n)
+	}
+	var survivor string
+	if err := s.db.QueryRow("SELECT id FROM memories").Scan(&survivor); err != nil {
+		t.Fatalf("read survivor: %v", err)
+	}
+	if survivor != "newest" {
+		t.Errorf("survivor = %q, want newest — a capped run must drain oldest-first", survivor)
+	}
+	assertNoOrphans(t, s)
+}
+
+func TestDeleteByScopeRequiresACondition(t *testing.T) {
+	s := newScopeTestStore(t)
+	if _, err := s.DeleteByScope(context.Background(), DeleteScopeOptions{Hard: true}); err == nil {
+		t.Fatal("an unscoped hard delete must be refused, not treated as delete-everything")
+	}
+}

--- a/pkg/memory/sqlite_temporal.go
+++ b/pkg/memory/sqlite_temporal.go
@@ -151,38 +151,18 @@ func copyEmbeddingVectorsToRevisionTx(
 	return nil
 }
 
-func (s *SQLiteStore) softDeleteByScopeTemporal(
-	ctx context.Context,
-	where string,
-	args []any,
-) (int, error) {
+// softDeleteIDsTemporal tombstones an already-resolved id list in one
+// transaction. DeleteByScope resolves ids up front so that a capped run is
+// deterministic, so the scope variant delegates here rather than re-querying.
+func (s *SQLiteStore) softDeleteIDsTemporal(ctx context.Context, ids []string) (int, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return 0, fmt.Errorf("begin soft delete by scope: %w", err)
 	}
 	defer tx.Rollback()
-
-	rows, err := tx.QueryContext(
-		ctx, "SELECT id FROM memories WHERE deleted_at IS NULL AND "+where, args...,
-	)
-	if err != nil {
-		return 0, fmt.Errorf("list soft-delete scope: %w", err)
-	}
-	var ids []string
-	for rows.Next() {
-		var id string
-		if err := rows.Scan(&id); err != nil {
-			rows.Close()
-			return 0, err
-		}
-		ids = append(ids, id)
-	}
-	if err := rows.Close(); err != nil {
-		return 0, err
-	}
-	if err := rows.Err(); err != nil {
-		return 0, err
-	}
 
 	for _, id := range ids {
 		if err := s.softDeleteMemoryTx(ctx, tx, id); err != nil {

--- a/pkg/memory/sqlite_temporal.go
+++ b/pkg/memory/sqlite_temporal.go
@@ -151,29 +151,15 @@ func copyEmbeddingVectorsToRevisionTx(
 	return nil
 }
 
-// softDeleteIDsTemporal tombstones an already-resolved id list in one
-// transaction. DeleteByScope resolves ids up front so that a capped run is
-// deterministic, so the scope variant delegates here rather than re-querying.
-func (s *SQLiteStore) softDeleteIDsTemporal(ctx context.Context, ids []string) (int, error) {
-	if len(ids) == 0 {
-		return 0, nil
-	}
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return 0, fmt.Errorf("begin soft delete by scope: %w", err)
-	}
-	defer tx.Rollback()
-
+// softDeleteIDsTx tombstones an already-resolved id list inside the caller's
+// transaction. DeleteByScope resolves and deletes in one transaction so a
+// concurrent re-scope cannot slip between the two, so this must not open its
+// own; the caller owns the commit and the cache eviction that follows it.
+func (s *SQLiteStore) softDeleteIDsTx(ctx context.Context, tx *sql.Tx, ids []string) (int, error) {
 	for _, id := range ids {
 		if err := s.softDeleteMemoryTx(ctx, tx, id); err != nil {
 			return 0, fmt.Errorf("soft delete %s by scope: %w", id, err)
 		}
-	}
-	if err := tx.Commit(); err != nil {
-		return 0, fmt.Errorf("commit soft delete by scope: %w", err)
-	}
-	for _, id := range ids {
-		s.cache.Remove(id)
 	}
 	return len(ids), nil
 }

--- a/pkg/memory/store.go
+++ b/pkg/memory/store.go
@@ -106,6 +106,15 @@ type DeleteScopeOptions struct {
 	Category  string
 	Source    string
 	Hard      bool
+	// OlderThan restricts the scope to memories created strictly before this
+	// instant. Zero value disables the filter.
+	OlderThan time.Time
+	// Limit caps how many memories a single call removes. Zero means no cap.
+	// Targets are resolved once, ordered by created_at, so repeated capped
+	// runs drain oldest-first instead of re-picking arbitrary rows.
+	Limit int
+	// DryRun resolves and counts the scope without deleting anything.
+	DryRun bool
 }
 
 type Store interface {


### PR DESCRIPTION
An investigation into sustained CPU use by `anchored` found the cause was not corpus size, as first assumed, but a `WHERE` clause that made a loop's exit condition unsatisfiable. On the affected machine CPU went from **206% to 1.5%** without removing a single memory.

Seven more defects surfaced along the way, two of them found by an adversarial review of this branch's own first commits.

## The root cause

`PutEmbeddingVector`'s upsert never set `content_hash` on conflict, and gated `DO UPDATE` on the stored hash already equalling the incoming one:

```sql
DO UPDATE SET embedding = ..., embedded_at = ...
WHERE memory_embedding_vectors.content_hash = excluded.content_hash
```

A row carrying a stale stamp could never be corrected: the conflict fired, the `WHERE` was false, the update was dropped, and the call returned `nil` — a silent no-op reported as success.

The consequences compound. The worker's own "missing" query keys off the same equality, so it kept handing back the same revisions; `anchored backfill` reported "N still missing — run again" on every run without converging; the generation stayed `building`, which keeps semantic search disabled; and the embedding worker re-embedded the same rows indefinitely, in the hub daemon *and* every per-session MCP. That loop was the standing CPU cost, with the oldest queued job 33 days old and getting older.

| | Before | After |
|---|---|---|
| CPU (instantaneous, 12 cores) | 206.0% | **1.5%** |
| Processes | 6 | 3 |
| Oldest queued job | 794h | 0 |
| Embedding generation | `building` | `active` |
| Semantic search | disabled | active |

## Commits

| Commit | What |
|---|---|
| `02f6c28` | `anchored forget` gains `--category`, `--older-than`, `--limit`, `--dry-run` by default |
| `e509a9e` | **The fix above** |
| `709b5bf` | nil-deref killed any subcommand given an unknown flag — `anchored search --help` died with SIGSEGV |
| `34e70a0` | `dream` aborted the whole run on a single NULL `content_hash` |
| `5a0ee9b` | Artifact capture wrote unconditionally while its Evictor was gated — 23k expired chunks, ~300 MB |
| `524aa79` | **Two data-loss paths** an adversarial review found in `02f6c28` |
| `4b88678` | `SearchOptions.MaxResults` was ignored; `--limit 100` returned `search.max_results` rows |
| `91e06f6` | Anti-slop pass over this branch |

## The two data-loss paths

Both were in this branch's own code, both found by review, both fixed in `524aa79`.

**`parseAge` overflowed.** `time.Duration` is int64 nanoseconds, so `>=106752d` wrapped negative and `now.Add(-age)` produced a cutoff in the *future*, matching every row. `--older-than 9999999999d --hard --yes` — a script passing epoch seconds where days were meant — would have deleted the entire corpus. Now bounded to `1d..36500d`.

**`DeleteByScope` resolved its ids outside the transaction** and deleted them inside it. The previous code re-evaluated the predicate within the transaction. With `_txlock=immediate` the write lock is taken at `BEGIN`, so the resolve phase was unprotected: a concurrent `anchored_update` re-categorizing a memory during the scan would still have it deleted under the old category. The resolve now happens inside the transaction, which keeps the deterministic oldest-first `--limit` draining with none of the exposure.

## Notes for review

- `dream_actions` references memories through two columns with **no foreign key on either**, so scope deletes must clear both explicitly. `TestSeedFillsEverySatellite` pins that every table the orphan assertion checks is actually populated by the seed — two assertions previously passed vacuously.
- `memory_embedding_vectors` is *not* cleared explicitly: it rides the FK cascade off `memory_revisions`, which is why revisions must be deleted before memories. The test asserts the cascade fires rather than assuming it.
- Bulk mode is CLI-only. The `anchored_forget` MCP tool still takes a single required id, so an agent cannot reach it.
- A database already affected by the root cause needs a one-time repair for the corrected path to rewrite the stale rows: `DELETE FROM memory_embedding_vectors WHERE content_hash = ''`.

## Known gap, not addressed here

Some live write path still leaves `memories.content_hash` NULL — 9 rows, two of them created within the last five days. Migration `003` normalizes NULL to `''` but runs once, so it does not cover new writes. `saveTemporal:298` computes the hash and `upsertCurrentMemoryTx` binds it correctly; the likely culprit is the revision-projection call at `sqlite_temporal.go:386`. Not chased down, and out of scope for this branch.

## Verification

`CGO_CFLAGS="-DSQLITE_ENABLE_FTS5" CGO_LDFLAGS="-lm" go test ./...` — 17 packages pass. `go vet ./...` clean. `gofmt -l` empty across every changed file.

`make lint` could **not** be run: `golangci-lint` is not installed in this environment (`Makefile:38` exits 127). `go vet` and `gofmt` are not equivalent to it.
