### PR TITLE
fix(memory): memórias do stop hook e do dream nasciam fora do ledger temporal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Memories orphaned from the temporal ledger** — the stop hook's lightweight
+  insert wrote straight into `memories` without `logical_id` or
+  `current_revision_id`, and the dream consolidator's synthesis did the same.
+  Curation resolves a memory through `current_revision_id` and the embedding
+  queue joins on it, so those rows were reachable by neither: nightly curation
+  failed on each of them with `explicit temporal write requires logical
+  identity` while the run still reported `failed=0`, and they never received an
+  embedding, leaving them searchable by BM25 only. Both paths now record a base
+  revision in the same transaction as the row, and migration
+  `021_backfill_ledger_orphans` adopts the rows earlier versions left behind
+  (base revision for active rows, tombstone for soft-deleted ones).
 - **The nightly `maintenance run` burned hours of CPU** — on this machine the
   import step grew from 31 minutes to **6h57m of CPU time** over a week, and the
   cause was one line on the save path. Every save that misses the exact content

--- a/cmd/anchored/hook_stop.go
+++ b/cmd/anchored/hook_stop.go
@@ -367,7 +367,8 @@ func openHookContextWrite(configPath string) (*HookContext, error) {
 }
 
 // saveMemoryLightweight performs a raw INSERT into memories with embedding=NULL.
-// The curation worker will compute the embedding asynchronously.
+// The curation worker will compute the embedding asynchronously, which it can
+// only do once the row carries a base revision, so both land in one tx.
 func saveMemoryLightweight(ctx context.Context, hc *HookContext, id, projectID, category, content, sessionID string) error {
 	hash := contentHashStop(content)
 	now := time.Now().UTC()
@@ -397,15 +398,52 @@ func saveMemoryLightweight(ctx context.Context, hc *HookContext, id, projectID, 
 		projID = &projectID
 	}
 
-	_, err = hc.db.ExecContext(ctx,
+	tx, err := hc.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin lightweight save: %w", err)
+	}
+	defer tx.Rollback()
+
+	revisionID := newHookID()
+	res, err := tx.ExecContext(ctx,
 		`INSERT OR IGNORE INTO memories
 		 (id, project_id, category, content, content_hash, keywords, embedding,
-		  source, created_at, updated_at, access_count, metadata, sync_dirty)
-		 VALUES (?, ?, ?, ?, ?, '[]', NULL, 'stop_hook', ?, ?, 0, ?, 0)`,
+		  source, created_at, updated_at, access_count, metadata, sync_dirty,
+		  logical_id, current_revision_id)
+		 VALUES (?, ?, ?, ?, ?, '[]', NULL, 'stop_hook', ?, ?, 0, ?, 0, ?, ?)`,
 		id, projID, category, content, hash,
-		now, now, string(metaJSON),
+		now, now, string(metaJSON), id, revisionID,
 	)
-	return err
+	if err != nil {
+		return err
+	}
+	inserted, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if inserted == 0 {
+		// OR IGNORE swallowed a duplicate id: the existing row keeps its own
+		// revision, so recording another one would fork the ledger.
+		return tx.Commit()
+	}
+
+	// The base revision is not bookkeeping: curation resolves a memory through
+	// memories.current_revision_id, and the embedding queue joins on it. A row
+	// without one is invisible to both.
+	if _, err := tx.ExecContext(ctx,
+		`INSERT OR IGNORE INTO memory_revisions
+		 (revision_id, memory_id, logical_id, project_id, category,
+		  content, content_hash, keywords, source, metadata,
+		  memory_created_at, memory_updated_at,
+		  temporal_mode, is_tombstone, valid_from, valid_to, system_from, system_to)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, '[]', 'stop_hook', ?, ?, ?, 'supersede', FALSE, ?, NULL, ?, NULL)`,
+		revisionID, id, id, projID, category, content, hash, string(metaJSON),
+		now, now, now.UnixNano(), now.UnixNano(),
+	); err != nil {
+		return fmt.Errorf("insert base revision: %w", err)
+	}
+
+	return tx.Commit()
 }
 
 // contentHashStop computes SHA-256 of content (same as sqlite_store.go).

--- a/cmd/anchored/hook_stop_test.go
+++ b/cmd/anchored/hook_stop_test.go
@@ -18,35 +18,18 @@ import (
 
 // ── schema helper ─────────────────────────────────────────────────────────────
 
-// newStopTestDB creates an in-memory SQLite DB with the minimal memories schema
-// used by the stop hook (no FTS5 needed: stop hook only does plain INSERT/SELECT).
+// newStopTestDB creates a SQLite DB carrying the real production schema, so a
+// column the stop hook must populate cannot go missing here and pass anyway.
 func newStopTestDB(t *testing.T) *sql.DB {
 	t.Helper()
-	db, err := sql.Open("sqlite3", ":memory:")
+	path := filepath.Join(t.TempDir(), "stop.db")
+	db, err := sql.Open("sqlite3", path+"?_journal_mode=WAL&_busy_timeout=5000&_foreign_keys=on")
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { db.Close() })
-	_, err = db.Exec(`
-		CREATE TABLE memories (
-			id               TEXT PRIMARY KEY,
-			project_id       TEXT,
-			category         TEXT NOT NULL,
-			content          TEXT NOT NULL,
-			content_hash     TEXT,
-			keywords         TEXT DEFAULT '[]',
-			embedding        BLOB,
-			source           TEXT,
-			created_at       DATETIME,
-			updated_at       DATETIME,
-			access_count     INTEGER DEFAULT 0,
-			metadata         TEXT,
-			sync_dirty       INTEGER DEFAULT 0,
-			deleted_at       DATETIME
-		);
-	`)
-	if err != nil {
-		t.Fatal(err)
+	if err := memory.Migrate(db); err != nil {
+		t.Fatalf("migrate: %v", err)
 	}
 	return db
 }
@@ -656,5 +639,113 @@ func TestSignificantTokenSet_SplitsOnPunctuation(t *testing.T) {
 	}
 	if set["7000"] || set["call"] {
 		t.Errorf("short tokens must be dropped: %v", set)
+	}
+}
+
+// ── base revision in the temporal ledger ─────────────────────────────────────
+
+// TestStopHook_SaveLightweight_RecordsBaseRevision verifies the lightweight
+// insert joins the temporal ledger: curation resolves a memory through
+// memories.current_revision_id and the embedding queue joins on it, so a row
+// without a base revision is invisible to both.
+func TestStopHook_SaveLightweight_RecordsBaseRevision(t *testing.T) {
+	db := newStopTestDB(t)
+	hc := &HookContext{db: db}
+	ctx := context.Background()
+
+	const id = "stop-revision-1"
+	content := "A causa raiz foi a ausência de revisão base, o que deixava a memória fora da fila de embedding."
+	if err := saveMemoryLightweight(ctx, hc, id, "proj-A", "learning", content, "sess-1"); err != nil {
+		t.Fatalf("saveMemoryLightweight: %v", err)
+	}
+
+	var logicalID, revisionID string
+	if err := db.QueryRowContext(ctx,
+		`SELECT COALESCE(logical_id, ''), COALESCE(current_revision_id, '') FROM memories WHERE id = ?`, id,
+	).Scan(&logicalID, &revisionID); err != nil {
+		t.Fatalf("query memory: %v", err)
+	}
+	if logicalID != id {
+		t.Errorf("logical_id = %q, want %q", logicalID, id)
+	}
+	if revisionID == "" {
+		t.Fatal("current_revision_id is empty: the memory is orphaned from the ledger")
+	}
+
+	var mode string
+	var tombstone bool
+	var validFrom int64
+	var validTo, systemTo sql.NullInt64
+	if err := db.QueryRowContext(ctx,
+		`SELECT temporal_mode, is_tombstone, valid_from, valid_to, system_to
+		 FROM memory_revisions WHERE revision_id = ? AND memory_id = ? AND logical_id = ?`,
+		revisionID, id, id,
+	).Scan(&mode, &tombstone, &validFrom, &validTo, &systemTo); err != nil {
+		t.Fatalf("query revision: %v", err)
+	}
+	if mode != "supersede" {
+		t.Errorf("temporal_mode = %q, want supersede", mode)
+	}
+	if tombstone {
+		t.Error("base revision must not be a tombstone")
+	}
+	if validFrom == 0 {
+		t.Error("valid_from must be set")
+	}
+	if validTo.Valid || systemTo.Valid {
+		t.Error("base revision must stay open on both time axes")
+	}
+}
+
+// TestStopHook_SaveLightweight_DuplicateKeepsOneRevision verifies that the
+// INSERT OR IGNORE dedupe path does not fork the ledger with a second revision
+// pointing at a row that already has one.
+func TestStopHook_SaveLightweight_DuplicateKeepsOneRevision(t *testing.T) {
+	db := newStopTestDB(t)
+	hc := &HookContext{db: db}
+	ctx := context.Background()
+
+	const id = "stop-revision-dup"
+	content := "Decidimos manter uma única revisão base por memória inserida pelo hook."
+	for i := 0; i < 3; i++ {
+		if err := saveMemoryLightweight(ctx, hc, id, "proj-A", "decision", content, "sess-1"); err != nil {
+			t.Fatalf("saveMemoryLightweight #%d: %v", i+1, err)
+		}
+	}
+
+	var revisions int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM memory_revisions WHERE memory_id = ?`, id,
+	).Scan(&revisions); err != nil {
+		t.Fatalf("count revisions: %v", err)
+	}
+	if revisions != 1 {
+		t.Errorf("revisions = %d, want 1", revisions)
+	}
+}
+
+// TestStopHook_SaveLightweight_CurationCanUpdateMetadata is the regression that
+// ties cause to symptom: nightly curation calls UpdateMetadata, which records a
+// system-time correction and needs the revision the correction applies to.
+func TestStopHook_SaveLightweight_CurationCanUpdateMetadata(t *testing.T) {
+	store, err := memory.NewSQLiteStore(filepath.Join(t.TempDir(), "curation.db"), nil)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	hc := &HookContext{db: store.DB()}
+	ctx := context.Background()
+
+	const id = "stop-curation-1"
+	if err := saveMemoryLightweight(ctx, hc, id, "", "learning",
+		"Aprendemos que a curadoria noturna precisa de uma revisão base para reescrever metadados.",
+		"sess-1",
+	); err != nil {
+		t.Fatalf("saveMemoryLightweight: %v", err)
+	}
+
+	if err := store.UpdateMetadata(ctx, id, map[string]any{"curation_status": "low_signal"}); err != nil {
+		t.Fatalf("UpdateMetadata on a stop-hook memory: %v", err)
 	}
 }

--- a/pkg/dream/consolidator.go
+++ b/pkg/dream/consolidator.go
@@ -320,13 +320,31 @@ func (c *DreamConsolidator) applySynthesize(ctx context.Context, action *DreamAc
 	defer tx.Rollback()
 
 	newID := newDreamID()
+	revisionID := newDreamID()
 	if _, err := tx.ExecContext(ctx, `
 		INSERT INTO memories (id, project_id, category, content, content_hash, keywords, embedding,
-		                      source, created_at, updated_at, access_count, metadata, sync_dirty)
+		                      source, created_at, updated_at, access_count, metadata, sync_dirty,
+		                      logical_id, current_revision_id)
 		VALUES (?, NULLIF(?, ''), 'summary', ?, '', '[]', NULL, 'dream_consolidation',
-		        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0, ?, 0)`,
-		newID, members[0].projectID, content, string(metaJSON)); err != nil {
+		        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0, ?, 0, ?, ?)`,
+		newID, members[0].projectID, content, string(metaJSON), newID, revisionID); err != nil {
 		return nil, fmt.Errorf("insert synthesis memory: %w", err)
+	}
+
+	// Curation resolves a memory through memories.current_revision_id and the
+	// embedding queue joins on it, so a synthesis without a base revision would
+	// never be scored nor embedded.
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO memory_revisions (
+			revision_id, memory_id, logical_id, project_id, category,
+			content, content_hash, keywords, source, metadata,
+			memory_created_at, memory_updated_at,
+			temporal_mode, is_tombstone, valid_from, valid_to, system_from, system_to)
+		VALUES (?, ?, ?, NULLIF(?, ''), 'summary', ?, '', '[]', 'dream_consolidation', ?,
+		        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'supersede', FALSE, ?, NULL, ?, NULL)`,
+		revisionID, newID, newID, members[0].projectID, content, string(metaJSON),
+		time.Now().UTC().UnixNano(), time.Now().UTC().UnixNano()); err != nil {
+		return nil, fmt.Errorf("insert synthesis base revision: %w", err)
 	}
 
 	// Demote (never delete) the raw members. curation_rule=consolidated is

--- a/pkg/dream/consolidator_test.go
+++ b/pkg/dream/consolidator_test.go
@@ -407,3 +407,63 @@ func TestApplyAction_Synthesize_CreatesSummaryAndDemotes(t *testing.T) {
 		}
 	}
 }
+
+// TestApplyAction_Synthesize_RecordsBaseRevision covers the synthesis row's
+// membership in the temporal ledger: curation resolves a memory through
+// memories.current_revision_id and the embedding queue joins on it, so a
+// synthesis without a base revision would be scored by neither.
+func TestApplyAction_Synthesize_RecordsBaseRevision(t *testing.T) {
+	ctx := context.Background()
+	db := setupConsolidatorTestDB(t)
+	c := NewConsolidator(db, nil)
+
+	insertTestMemory(t, ctx, db, "mem-a", "the deploy pipeline requires TAG_NAME and DEPLOY_REASON")
+	insertTestMemory(t, ctx, db, "mem-b", "deploy pipeline validation needs TAG_NAME plus a reason")
+	insertTestMemory(t, ctx, db, "mem-c", "pipeline deploys are tag-driven with mandatory reason")
+	insertTestDreamAction(t, ctx, db, "act-rev", "mem-a", "mem-b,mem-c", "synthesize", 0.9, "proposed")
+
+	result, err := c.ApplyAction(ctx, "act-rev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != "applied" {
+		t.Fatalf("want applied, got %q (%s)", result.Status, result.Message)
+	}
+
+	var id, logicalID, revisionID string
+	if err := db.QueryRowContext(ctx, `
+		SELECT id, COALESCE(logical_id, ''), COALESCE(current_revision_id, '')
+		FROM memories WHERE source = 'dream_consolidation' AND deleted_at IS NULL`,
+	).Scan(&id, &logicalID, &revisionID); err != nil {
+		t.Fatalf("synthesis memory not found: %v", err)
+	}
+	if logicalID != id {
+		t.Errorf("logical_id = %q, want %q", logicalID, id)
+	}
+	if revisionID == "" {
+		t.Fatal("current_revision_id is empty: the synthesis is orphaned from the ledger")
+	}
+
+	var mode, category string
+	var tombstone bool
+	var validTo, systemTo sql.NullInt64
+	if err := db.QueryRowContext(ctx, `
+		SELECT temporal_mode, category, is_tombstone, valid_to, system_to
+		FROM memory_revisions WHERE revision_id = ? AND memory_id = ? AND logical_id = ?`,
+		revisionID, id, id,
+	).Scan(&mode, &category, &tombstone, &validTo, &systemTo); err != nil {
+		t.Fatalf("query revision: %v", err)
+	}
+	if mode != "supersede" {
+		t.Errorf("temporal_mode = %q, want supersede", mode)
+	}
+	if category != "summary" {
+		t.Errorf("revision category = %q, want summary", category)
+	}
+	if tombstone {
+		t.Error("base revision must not be a tombstone")
+	}
+	if validTo.Valid || systemTo.Valid {
+		t.Error("base revision must stay open on both time axes")
+	}
+}

--- a/pkg/memory/sqlite_migrations.go
+++ b/pkg/memory/sqlite_migrations.go
@@ -12,6 +12,91 @@ type migration struct {
 	Up   string
 }
 
+// migrationBackfillLedgerOrphans re-runs 018's ledger backfill for rows that
+// were created after 018 applied. Migration 018 only reached the corpus that
+// existed when it ran, so any later write path that skipped the ledger left
+// rows with no revision — unreachable to curation and to the embedding queue.
+const migrationBackfillLedgerOrphans = `
+			UPDATE memories
+			SET logical_id = id
+			WHERE logical_id IS NULL OR logical_id = '';
+
+			INSERT OR IGNORE INTO memory_revisions (
+				revision_id, memory_id, logical_id, project_id, category,
+				content, content_hash, keywords, source, source_id, metadata,
+				memory_created_at, memory_updated_at, author, remote_project_key,
+				temporal_mode, is_tombstone, valid_from, valid_to,
+				system_from, system_to, created_at
+			)
+			SELECT
+				'legacy:' || id || ':base',
+				id,
+				id,
+				project_id,
+				category,
+				content,
+				content_hash,
+				keywords,
+				source,
+				source_id,
+				metadata,
+				COALESCE(created_at, CURRENT_TIMESTAMP),
+				COALESCE(updated_at, created_at, CURRENT_TIMESTAMP),
+				author,
+				remote_project_key,
+				'supersede',
+				FALSE,
+				CAST(strftime('%s', COALESCE(created_at, CURRENT_TIMESTAMP)) AS INTEGER) * 1000000000,
+				NULL,
+				CAST(strftime('%s', COALESCE(created_at, CURRENT_TIMESTAMP)) AS INTEGER) * 1000000000,
+				NULL,
+				COALESCE(created_at, CURRENT_TIMESTAMP)
+			FROM memories
+			WHERE deleted_at IS NULL
+				AND (current_revision_id IS NULL OR current_revision_id = '');
+
+			INSERT OR IGNORE INTO memory_revisions (
+				revision_id, memory_id, logical_id, project_id, category,
+				content, content_hash, keywords, source, source_id, metadata,
+				memory_created_at, memory_updated_at, author, remote_project_key,
+				temporal_mode, is_tombstone, valid_from, valid_to,
+				system_from, system_to, created_at
+			)
+			SELECT
+				'legacy:' || id || ':tombstone',
+				id,
+				id,
+				project_id,
+				category,
+				content,
+				content_hash,
+				keywords,
+				source,
+				source_id,
+				metadata,
+				COALESCE(created_at, CURRENT_TIMESTAMP),
+				COALESCE(updated_at, deleted_at, created_at, CURRENT_TIMESTAMP),
+				author,
+				remote_project_key,
+				'tombstone',
+				TRUE,
+				CAST(strftime('%s', deleted_at) AS INTEGER) * 1000000000,
+				NULL,
+				CAST(strftime('%s', deleted_at) AS INTEGER) * 1000000000,
+				NULL,
+				deleted_at
+			FROM memories
+			WHERE deleted_at IS NOT NULL
+				AND (current_revision_id IS NULL OR current_revision_id = '');
+
+			UPDATE memories
+			SET current_revision_id = CASE
+				WHEN deleted_at IS NULL THEN 'legacy:' || id || ':base'
+				ELSE 'legacy:' || id || ':tombstone'
+			END
+			WHERE current_revision_id IS NULL OR current_revision_id = '';
+		`
+
 func Migrate(db *sql.DB) error {
 	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS migrations (
 		id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -422,6 +507,7 @@ func Migrate(db *sql.DB) error {
 			CREATE INDEX IF NOT EXISTS idx_memories_normalized_hash
 				ON memories(normalized_hash, project_id);
 		`},
+		{Name: "021_backfill_ledger_orphans", Up: migrationBackfillLedgerOrphans},
 	}
 
 	for _, m := range migrations {

--- a/pkg/memory/sqlite_migrations_backfill_test.go
+++ b/pkg/memory/sqlite_migrations_backfill_test.go
@@ -1,0 +1,113 @@
+package memory
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+// TestBackfillLedgerOrphans_AdoptsRowsWithoutRevision covers the rows a write
+// path left outside the temporal ledger after migration 018 had already run:
+// curation resolves a memory through memories.current_revision_id and the
+// embedding queue joins on it, so an orphan is invisible to both.
+func TestBackfillLedgerOrphans_AdoptsRowsWithoutRevision(t *testing.T) {
+	store, err := NewSQLiteStore(filepath.Join(t.TempDir(), "backfill.db"), nil)
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	defer store.Close()
+	db := store.DB()
+	ctx := context.Background()
+
+	// Reproduce both orphan shapes: an active row and a soft-deleted one.
+	for _, o := range []struct{ id, deletedAt string }{
+		{"orphan-active", ""},
+		{"orphan-deleted", "2026-09-01 10:00:00"},
+	} {
+		var deleted any
+		if o.deletedAt != "" {
+			deleted = o.deletedAt
+		}
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO memories
+			 (id, category, content, content_hash, keywords, source,
+			  created_at, updated_at, access_count, metadata, sync_dirty, deleted_at)
+			 VALUES (?, 'learning', 'conteudo orfao', 'hash', '[]', 'stop_hook',
+			         '2026-08-27 12:00:00', '2026-08-27 12:00:00', 0, '{}', 0, ?)`,
+			o.id, deleted,
+		); err != nil {
+			t.Fatalf("insert orphan %s: %v", o.id, err)
+		}
+	}
+
+	orphans := func() int {
+		t.Helper()
+		var n int
+		if err := db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM memories
+			 WHERE current_revision_id IS NULL OR current_revision_id = ''`,
+		).Scan(&n); err != nil {
+			t.Fatalf("count orphans: %v", err)
+		}
+		return n
+	}
+
+	if got := orphans(); got != 2 {
+		t.Fatalf("orphans before backfill = %d, want 2", got)
+	}
+
+	if _, err := db.ExecContext(ctx, migrationBackfillLedgerOrphans); err != nil {
+		t.Fatalf("apply backfill: %v", err)
+	}
+	if got := orphans(); got != 0 {
+		t.Errorf("orphans after backfill = %d, want 0", got)
+	}
+
+	// The active row gets an open base revision; the deleted one a tombstone.
+	for _, want := range []struct {
+		id, mode  string
+		tombstone bool
+	}{
+		{"orphan-active", "supersede", false},
+		{"orphan-deleted", "tombstone", true},
+	} {
+		var mode, logicalID string
+		var tombstone bool
+		var systemTo sql.NullInt64
+		if err := db.QueryRowContext(ctx,
+			`SELECT r.temporal_mode, r.logical_id, r.is_tombstone, r.system_to
+			 FROM memories m JOIN memory_revisions r ON r.revision_id = m.current_revision_id
+			 WHERE m.id = ?`, want.id,
+		).Scan(&mode, &logicalID, &tombstone, &systemTo); err != nil {
+			t.Fatalf("resolve revision for %s: %v", want.id, err)
+		}
+		if mode != want.mode {
+			t.Errorf("%s: temporal_mode = %q, want %q", want.id, mode, want.mode)
+		}
+		if tombstone != want.tombstone {
+			t.Errorf("%s: is_tombstone = %v, want %v", want.id, tombstone, want.tombstone)
+		}
+		if logicalID != want.id {
+			t.Errorf("%s: logical_id = %q, want %q", want.id, logicalID, want.id)
+		}
+		if systemTo.Valid {
+			t.Errorf("%s: system_to must stay open", want.id)
+		}
+	}
+
+	// Idempotent: the backfill runs inside a migration that may be replayed on
+	// a database that already has revisions for every row.
+	if _, err := db.ExecContext(ctx, migrationBackfillLedgerOrphans); err != nil {
+		t.Fatalf("re-apply backfill: %v", err)
+	}
+	var revisions int
+	if err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM memory_revisions WHERE memory_id = 'orphan-active'`,
+	).Scan(&revisions); err != nil {
+		t.Fatalf("count revisions: %v", err)
+	}
+	if revisions != 1 {
+		t.Errorf("revisions for orphan-active = %d, want 1", revisions)
+	}
+}


### PR DESCRIPTION
A curadoria noturna falhava em 63 memórias, toda noite, havia um mês — e o run terminava dizendo `failed=0`:

```
metadata update failed for <id>: explicit temporal write requires logical identity
   (503 ocorrências em 14 dias, sempre as mesmas 63)
Reconciled 57661 memories
maintenance: run complete steps=4 failed=0
```

O caminho leve do stop hook (`saveMemoryLightweight`) fazia `INSERT OR IGNORE INTO memories` direto, sem `logical_id` nem `current_revision_id`, e a síntese do dream consolidator fazia o mesmo. Como a curadoria resolve a memória por `current_revision_id` e a fila de embedding faz `JOIN` nele, essas linhas eram inalcançáveis pelas duas: nunca eram re-scoradas e **nunca recebiam embedding**, ficando pesquisáveis só por BM25. Eram exatamente o 1% que o `doctor` reportava como `57601/57664 embedded` — 29 `decision` e 22 `learning`, as categorias de maior valor do acervo.

## Changes

- **revisão base na mesma transação da linha**: os dois caminhos de escrita passam a gravar a revisão em `memory_revisions` junto com o `INSERT`, e o dedupe do `OR IGNORE` não cria uma segunda revisão para uma linha que já tem a sua.
- **migração `021_backfill_ledger_orphans`**: adota as linhas que versões anteriores deixaram fora — revisão base para as ativas, tombstone para as soft-deleted. O SQL virou a constante `migrationBackfillLedgerOrphans` para o backfill em si ficar sob teste, em vez de inalcançável dentro do slice de migrações.
- **`newStopTestDB` agora roda contra o schema real** (`memory.Migrate`). Ele montava uma cópia enxuta sem as colunas que o hook precisa popular, e era por isso que a lacuna passava verde: um helper que reimplementa o schema à mão vira um oráculo que concorda com o bug.
- 4 testes novos. O de curadoria não inspeciona colunas — ele chama `store.UpdateMetadata`, o consumidor real, e falha com a mensagem exata que aparecia no journal.

## Verificação

Suíte completa com CGO + FTS5: 17 pacotes `ok`, `go vet` limpo. Os 4 testes novos rodados contra o commit anterior falham lá, incluindo `UpdateMetadata on a stop-hook memory: explicit temporal write requires logical identity`.

Aplicado num acervo real de 57.700 memórias: órfãs `63 → 0`, e o `doctor` passou de `99%` para `57700/57700 embedded (100%)`. `curation reconcile` depois do fix: `Reconciled 57684 / Updated metadata: 1895`, **zero** erros — antes eram 63 por execução.

**Não** entrou nesta entrega: a guarda estrutural que tornaria o atalho impossível (trigger `BEFORE INSERT` abortando `INSERT` sem `current_revision_id`). Foi implementada e medida — quebra 23 testes, todos fixtures que inserem direto em `memories`, nenhum caminho de produção. Arrastá-los faria este PR carregar um refactor de testes junto com o fix. Vale registrar que `NOT NULL` na coluna não serve: ela entrou por `ALTER TABLE` como nullable, e apertá-la exigiria recriar uma tabela de 58 mil linhas com triggers de FTS pendurados.

`make lint` não foi executado — `golangci-lint` não está instalado na máquina onde isto foi feito.
