### PR TITLE
fix(project): worktree resolve para o repositório, não para o próprio path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Worktrees started with no memory of their repository** — project identity
+  came from `git rev-parse --show-toplevel`, which in a linked worktree returns
+  the worktree's own path. Since projects are looked up by exact path, every
+  worktree got a project row of its own and therefore an empty memory, while
+  the repository's history stayed under the main checkout. Detection now
+  resolves the shared repository through `--git-common-dir`, so a worktree and
+  its main checkout are one project. Independent clones of the same remote stay
+  separate, which keeps a repository checked out for different operational
+  contexts from having its memory merged.
+
+- **Memories orphaned from the temporal ledger** — the stop hook's lightweight
+  insert wrote straight into `memories` without `logical_id` or
+  `current_revision_id`, and the dream consolidator's synthesis did the same.
+  Curation resolves a memory through `current_revision_id` and the embedding
+  queue joins on it, so those rows were reachable by neither: nightly curation
+  failed on each of them with `explicit temporal write requires logical
+  identity` while the run still reported `failed=0`, and they never received an
+  embedding, leaving them searchable by BM25 only. Both paths now record a base
+  revision in the same transaction as the row, and migration
+  `021_backfill_ledger_orphans` adopts the rows earlier versions left behind
+  (base revision for active rows, tombstone for soft-deleted ones).
 - **The nightly `maintenance run` burned hours of CPU** — on this machine the
   import step grew from 31 minutes to **6h57m of CPU time** over a week, and the
   cause was one line on the save path. Every save that misses the exact content

--- a/pkg/project/detector.go
+++ b/pkg/project/detector.go
@@ -90,12 +90,54 @@ func (d *Detector) Resolve(id string) (*Project, error) {
 	return &p, nil
 }
 
+// gitRoot returns the path that identifies the project. A linked worktree has
+// its own working tree but shares the repository, and the shared repository is
+// what carries the project's identity: --show-toplevel would return the
+// worktree, giving it a project row of its own and therefore an empty memory.
+// --git-common-dir resolves to the main repository in both cases.
 func gitRoot(dir string) (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	if root := gitCommonRoot(dir); root != "" {
+		return root, nil
+	}
+	out, err := gitOutput(dir, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", nil
+	}
+	return out, nil
+}
+
+// gitCommonRoot resolves the working tree of the shared repository, or "" when
+// dir is not inside a git repository.
+func gitCommonRoot(dir string) string {
+	// --path-format=absolute needs git >= 2.31; without it the common dir comes
+	// back relative to the process working directory in the main repository
+	// (plain ".git"), so the fallback resolves it against dir.
+	common, err := gitOutput(dir, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if err != nil || common == "" {
+		common, err = gitOutput(dir, "rev-parse", "--git-common-dir")
+		if err != nil || common == "" {
+			return ""
+		}
+		if !filepath.IsAbs(common) {
+			common = filepath.Join(dir, common)
+		}
+	}
+	common = filepath.Clean(common)
+
+	// A bare repository's common dir is the repository itself, with no working
+	// tree above it to step up into.
+	if filepath.Base(common) != ".git" {
+		return common
+	}
+	return filepath.Dir(common)
+}
+
+func gitOutput(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
 	out, err := cmd.Output()
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/pkg/project/detector_test.go
+++ b/pkg/project/detector_test.go
@@ -4,7 +4,9 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -392,4 +394,94 @@ func openTestDB(t *testing.T) *sql.DB {
 		t.Fatalf("create schema: %v", err)
 	}
 	return db
+}
+
+// TestDetect_WorktreeSharesMainProject covers the case a linked worktree used
+// to break: --show-toplevel returns the worktree's own path, so the worktree
+// got a project row of its own and started with no memory of the repository.
+func TestDetect_WorktreeSharesMainProject(t *testing.T) {
+	db := openTestDB(t)
+	d := NewDetector(db)
+
+	main := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(main, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, main, "init", "-q")
+	runGit(t, main, "config", "user.email", "t@example.com")
+	runGit(t, main, "config", "user.name", "t")
+	if err := os.WriteFile(filepath.Join(main, "f.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, main, "add", "f.txt")
+	runGit(t, main, "commit", "-qm", "init")
+
+	mainProject, err := d.Detect(main)
+	if err != nil || mainProject == nil {
+		t.Fatalf("detect main: %v (project=%v)", err, mainProject)
+	}
+
+	wt := filepath.Join(t.TempDir(), "wt")
+	runGit(t, main, "worktree", "add", "-q", "--detach", wt)
+
+	wtProject, err := d.Detect(wt)
+	if err != nil || wtProject == nil {
+		t.Fatalf("detect worktree: %v (project=%v)", err, wtProject)
+	}
+
+	if wtProject.ID != mainProject.ID {
+		t.Errorf("worktree resolved to project %s, want the main repository's %s",
+			wtProject.ID, mainProject.ID)
+	}
+	if wtProject.Path != mainProject.Path {
+		t.Errorf("worktree path = %q, want %q", wtProject.Path, mainProject.Path)
+	}
+
+	// A subdirectory of the worktree must resolve the same way.
+	sub := filepath.Join(wt, "nested")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	subProject, err := d.Detect(sub)
+	if err != nil || subProject == nil {
+		t.Fatalf("detect worktree subdir: %v", err)
+	}
+	if subProject.ID != mainProject.ID {
+		t.Errorf("worktree subdir resolved to %s, want %s", subProject.ID, mainProject.ID)
+	}
+
+	// Exactly one project row for the repository.
+	var rows int
+	if err := db.QueryRow("SELECT COUNT(*) FROM projects").Scan(&rows); err != nil {
+		t.Fatal(err)
+	}
+	if rows != 1 {
+		t.Errorf("projects rows = %d, want 1", rows)
+	}
+}
+
+// TestDetect_SeparateClonesStaySeparate guards the other side of the fix: two
+// independent clones are not worktrees and must keep their own projects, so a
+// repository checked out for different operational contexts does not get its
+// memory merged.
+func TestDetect_SeparateClonesStaySeparate(t *testing.T) {
+	db := openTestDB(t)
+	d := NewDetector(db)
+
+	var ids []string
+	for _, name := range []string{"clone-a", "clone-b"} {
+		dir := filepath.Join(t.TempDir(), name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		runGit(t, dir, "init", "-q")
+		p, err := d.Detect(dir)
+		if err != nil || p == nil {
+			t.Fatalf("detect %s: %v", name, err)
+		}
+		ids = append(ids, p.ID)
+	}
+	if ids[0] == ids[1] {
+		t.Error("independent clones collapsed into one project")
+	}
 }


### PR DESCRIPTION
Um worktree começava sem nenhuma memória do repositório. A identidade do projeto vinha de `git rev-parse --show-toplevel`, que num worktree devolve o path do próprio worktree:

```
                    --show-toplevel          --git-common-dir
principal   ~/Projetos/anchored/anchored     <repo>/.git
worktree    /tmp/wt-test                     <repo>/.git    ← igual
```

Como projetos são buscados por path exato (`WHERE path = ?`), o path diferente não casava, caía no `INSERT` com `newID()` e o worktree ganhava uma linha de projeto própria — e portanto memória vazia — enquanto o histórico do repositório continuava sob o checkout principal.

Medido num acervo real antes do fix: **45 worktrees haviam acumulado projetos próprios, com 1.215 memórias que o checkout principal não conseguia ver**. Vários apareciam com 0 memórias — sessões inteiras rodadas sem contexto algum.

A ironia é que o `remote_key` já é calculado por `deriveRemoteKey()` e já é estável entre worktrees; é o que faz o sync remoto funcionar. A chave canônica estava no banco desde sempre, só não era usada para resolver a identidade local.

## Changes

- **`gitRoot` resolve o repositório compartilhado** via `--git-common-dir`, que aponta para o mesmo `.git` dos dois lados. `--show-toplevel` fica como último recurso.
- **`--path-format=absolute` exige git ≥ 2.31**, então o fallback resolve o common dir relativo contra o diretório consultado — no repositório principal ele volta como `.git` puro. Repositório bare tem o common dir como o próprio repositório e não é subido um nível.
- **clones independentes continuam separados**, e isso é deliberado: o mesmo repositório com checkouts para contextos operacionais diferentes não pode ter a memória fundida. Há teste fixando esse lado.

## Verificação

Suíte completa com CGO + FTS5 verde, `go vet` limpo. `TestDetect_WorktreeSharesMainProject` cobre worktree, subdiretório de worktree e exige uma única linha em `projects`; contra o commit anterior ele falha com `projects rows = 2, want 1`. `TestDetect_SeparateClonesStaySeparate` guarda o lado oposto e passa nos dois estados, o que mostra que o fix não colapsa o que não deve.

Validado no acervo real: `anchored search "..." --cwd <worktree>` devolve o mesmo top-hit com score idêntico ao do checkout principal.

Este PR corrige a detecção, ou seja, vale para worktrees a partir de agora. **Consolidar os projetos já fragmentados é uma operação de dados separada**: depende de git e do filesystem para provar quais paths são worktrees, então não cabe numa migração SQL. Um `anchored project consolidate` com dry-run seria o caminho para distribuí-la, e não está aqui.

`make lint` não foi executado — `golangci-lint` não está instalado na máquina onde isto foi feito.
